### PR TITLE
:NORMAL: Feature/jitpack setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,38 @@ It also provides Fragment and Activity abstract classes / implementations for ea
 Finally, a demo app is included, to demonstrate how a Fusion app could be set up.
 
 ## Installation
-In order to utilise the core AndroidUi module in a project, add the following dependency to your `build.gradle` file:
+[JitPack](https://jitpack.io/) is used to provide the Fusion artifacts.
+In order to utilise the library in a project, update your `settings.gradle` (or root project `build.gradle` on older projects) to include the Jitpack maven repository:
 ```groovy
-    //TODO
+    repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+    }
+```
+Then, in order to utilise the core AndroidUi module in a project, add the following dependency to your `build.gradle` file:
+```groovy
+    implementation 'com.github.3sidedcube.Android-Fusion-AndroidUi:core:{versionCode}'
 ```
 To utilise the Fragment module, add the following dependency:
 ```groovy
-    //TODO
+    implementation 'com.github.3sidedcube.Android-Fusion-AndroidUi:fragment:{versionCode}'
 ```
 To utilise the Activity module, add the following dependency:
 ```groovy
-    //TODO
+    implementation 'com.github.3sidedcube.Android-Fusion-AndroidUi:activity:{versionCode}'
 ```
-[JitPack](https://jitpack.io/) is used to provide the Fusion artifacts.
+If you wish to utilise all modules in this repo, you can alternatively add the following dependency:
+```groovy
+    implementation 'com.github.3sidedcube:Android-Fusion-AndroidUi:{versionCode}'
+```
+As these builds are provided using Jitpack, `{versionCode}` can be replaced with:
+
+- A specific commit, e.g `1a2b3c4d5e`
+- A specific branch's latest build, e.g `feature~jitpack-setup-SNAPSHOT`
+- A specific pre-release tag, e.g `1.0.0-rc1`
+- A specific release tag, e.g `1.0.0`
+
+It is recommended that you use this library at a specific release tag, to ensure that the library is in a stable state.
 
 ## Usage
 See the demo app to get an impression of the behaviour, or see the Wiki.

--- a/activity/build.gradle
+++ b/activity/build.gradle
@@ -43,6 +43,6 @@ dependencies {
 	// Same-repo Fusion dependencies
 	implementation project(path: ":core")
 
-	// Core Fusion dependency
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:core:5f7807a715'
+	// Core Fusion dependency - specify version in the root build.gradle
+	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
 }

--- a/activity/build.gradle
+++ b/activity/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'com.android.library'
 	id 'kotlin-android'
+	id 'maven-publish'
 }
 
 android {
@@ -31,6 +32,23 @@ android {
 	}
 	buildFeatures {
 		viewBinding true
+	}
+
+	afterEvaluate {
+		publishing {
+			publications {
+				// Creates a Maven publication called "release".
+				release(MavenPublication) {
+					// Applies the component for the release build variant.
+					from components.release
+
+					// You can then customize attributes of the publication as shown below.
+					groupId = 'com.cube.fusion.android.activity'
+					artifactId = 'activity'
+					version = project.fusionLibVersion
+				}
+			}
+		}
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,32 @@ buildscript {
 	}
 }
 
+/**
+ * Gets the version of dependency Fusion libs, ensuring that (if building a pre-release or release build with Jitpack) it matches this library's version
+ *
+ * @param requiredVersion the version that is required for this project
+ * @return the consistent required version identifier for Fusion libs
+ */
+def withConsistentVersioning(requiredVersion) {
+	if("$System.env.JITPACK".toString() == "true") {
+		def jitpackVersion = "$System.env.VERSION".toString()
+		if(jitpackVersion ==~ /\w?\d+\.\d+\.\d+(-\w+)?/)
+		{
+			println "Pre-release or release version - checking for versioning consistency"
+			if(requiredVersion != jitpackVersion) {
+				throw new GradleException("Required version $requiredVersion does not match build version $jitpackVersion")
+			}
+		}
+	}
+	return requiredVersion
+}
+
+ext {
+	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
+	// Instead, update the argument passed to withConsistentVersioning to the target lib version
+	fusionLibVersion = withConsistentVersioning('5f7807a715')
+}
+
 task clean(type: Delete) {
 	delete rootProject.buildDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('5f7807a715')
+	fusionLibVersion = withConsistentVersioning('c7d04de47d')
 }
 
 task clean(type: Delete) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,6 @@ dependencies {
 	// Material design dependency
 	implementation 'com.google.android.material:material:1.5.0'
 
-	// Fusion dependencies
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:core:5f7807a715'
+	// Core Fusion dependency - specify version in the root build.gradle
+	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'com.android.library'
 	id 'kotlin-android'
 	id 'kotlin-parcelize'
+	id 'maven-publish'
 }
 
 android {
@@ -32,6 +33,23 @@ android {
 	}
 	buildFeatures {
 		viewBinding true
+	}
+
+	afterEvaluate {
+		publishing {
+			publications {
+				// Creates a Maven publication called "release".
+				release(MavenPublication) {
+					// Applies the component for the release build variant.
+					from components.release
+
+					// You can then customize attributes of the publication as shown below.
+					groupId = 'com.cube.fusion.android.core'
+					artifactId = 'core'
+					version = project.fusionLibVersion
+				}
+			}
+		}
 	}
 }
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -49,9 +49,10 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
 
-	// Same-repo Fusion dependencies: TODO replace with imports as above when Jitpack is integrated with this lib
-	implementation project(path: ":activity")
-	implementation project(path: ":core")
+	// Same-repo Fusion dependencies
+	def currentLibVersion = "feature~jitpack-setup-SNAPSHOT"
+	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
+	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 
 	// Image loading/populating
 	implementation 'com.squareup.picasso:picasso:2.71828'

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -45,9 +45,9 @@ dependencies {
 	// Lifecycle KTX
 	implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
 
-	// Fusion dependencies
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:core:5f7807a715'
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:populator-legacy:5f7807a715'
+	// Fusion dependencies - specify version in the root build.gradle
+	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
+	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies: TODO replace with imports as above when Jitpack is integrated with this lib
 	implementation project(path: ":activity")

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -8,6 +8,7 @@ import com.cube.fusion.android.activity.FusionContentActivity
 import com.cube.fusion.android.activity.actions.DefaultActivityActionHandlers
 import com.cube.fusion.android.core.config.AndroidFusionConfig
 import com.cube.fusion.android.core.databinding.ContentFragmentViewBinding
+import com.cube.fusion.android.core.databinding.ToolbarViewBinding
 import com.cube.fusion.android.core.helper.ViewHelper
 import com.cube.fusion.android.demoapp.databinding.ActivityFusionImplBinding
 import com.cube.fusion.android.demoapp.images.PicassoImageLoader
@@ -36,7 +37,10 @@ class ContentActivityImpl : FusionContentActivity() {
 	}
 
 	lateinit var binding: ActivityFusionImplBinding
-	override val contentBinding: ContentFragmentViewBinding get() = binding.pageContent
+	@Suppress("TYPE_MISMATCH") // Note: Android Studio incorrectly types this due to being part of the repo with the view in. This annotation would not be needed on an actual project.
+	override val contentBinding: ContentFragmentViewBinding by lazy { ContentFragmentViewBinding.bind(binding.pageContent) }
+	@Suppress("TYPE_MISMATCH") // Note: Android Studio incorrectly types this due to being part of the repo with the view in. This annotation would not be needed on an actual project.
+	private val toolbarBinding: ToolbarViewBinding by lazy { ToolbarViewBinding.bind(binding.toolbar) }
 	override val fusionConfig: AndroidFusionConfig = AndroidFusionConfig(
 		populator = LegacyDisplayPopulator,
 		actionHandler = DefaultActivityActionHandlers { view, action ->
@@ -51,7 +55,7 @@ class ContentActivityImpl : FusionContentActivity() {
 
 	override fun setTitle(title: CharSequence?) {
 		super.setTitle(title)
-		binding.toolbar.screenTitle.text = title
+		toolbarBinding.screenTitle.text = title
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,7 +63,7 @@ class ContentActivityImpl : FusionContentActivity() {
 		binding = ActivityFusionImplBinding.inflate(layoutInflater)
 		setContentView(binding.root)
 
-		binding.toolbar.backAction.setOnClickListener {
+		toolbarBinding.backAction.setOnClickListener {
 			finish()
 		}
 

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -37,10 +37,8 @@ class ContentActivityImpl : FusionContentActivity() {
 	}
 
 	lateinit var binding: ActivityFusionImplBinding
-	@Suppress("TYPE_MISMATCH") // Note: Android Studio incorrectly types this due to being part of the repo with the view in. This annotation would not be needed on an actual project.
-	override val contentBinding: ContentFragmentViewBinding by lazy { ContentFragmentViewBinding.bind(binding.pageContent) }
-	@Suppress("TYPE_MISMATCH") // Note: Android Studio incorrectly types this due to being part of the repo with the view in. This annotation would not be needed on an actual project.
-	private val toolbarBinding: ToolbarViewBinding by lazy { ToolbarViewBinding.bind(binding.toolbar) }
+	override lateinit var contentBinding: ContentFragmentViewBinding
+	private lateinit var toolbarBinding: ToolbarViewBinding
 	override val fusionConfig: AndroidFusionConfig = AndroidFusionConfig(
 		populator = LegacyDisplayPopulator,
 		actionHandler = DefaultActivityActionHandlers { view, action ->
@@ -58,15 +56,28 @@ class ContentActivityImpl : FusionContentActivity() {
 		toolbarBinding.screenTitle.text = title
 	}
 
+
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 		binding = ActivityFusionImplBinding.inflate(layoutInflater)
 		setContentView(binding.root)
+		setUpSubBindings()
 
 		toolbarBinding.backAction.setOnClickListener {
 			finish()
 		}
 
 		displayActivityPage(savedInstanceState)
+	}
+
+	@Suppress("TYPE_MISMATCH")
+	/**
+	 * Set up the sub-bindings needed for interacting with the whole view structure
+	 * NOTE: Android Studio incorrectly types binding properties due to being part of the repo with the view in.
+	 * The @Suppress annotation would not be needed on an actual project.
+	 */
+	private fun setUpSubBindings() {
+		contentBinding = ContentFragmentViewBinding.bind(binding.pageContent)
+		toolbarBinding = ToolbarViewBinding.bind(binding.toolbar)
 	}
 }

--- a/fragment/build.gradle
+++ b/fragment/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'com.android.library'
 	id 'kotlin-android'
+	id 'maven-publish'
 }
 
 android {
@@ -28,6 +29,23 @@ android {
 	}
 	kotlinOptions {
 		jvmTarget = '1.8'
+	}
+
+	afterEvaluate {
+		publishing {
+			publications {
+				// Creates a Maven publication called "release".
+				release(MavenPublication) {
+					// Applies the component for the release build variant.
+					from components.release
+
+					// You can then customize attributes of the publication as shown below.
+					groupId = 'com.cube.fusion.android.fragment'
+					artifactId = 'fragment'
+					version = project.fusionLibVersion
+				}
+			}
+		}
 	}
 }
 

--- a/fragment/build.gradle
+++ b/fragment/build.gradle
@@ -41,10 +41,10 @@ dependencies {
 	// Same-repo Fusion dependencies
 	implementation project(path: ":core")
 
-	// Core Fusion dependency
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:core:5f7807a715'
+	// Core Fusion dependency - specify version in the root build.gradle
+	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
 
 	// Legacy Fusion dependencies: TODO remove when removing legacy activity
 	implementation project(path: ":activity")
-	implementation 'com.github.3sidedcube.Android-Fusion-Core:populator-legacy:5f7807a715'
+	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Mar 03 13:32:09 GMT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,185 @@
+#!/usr/bin/env sh
+
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=`expr $i + 1`
+    done
+    case $i in
+        0) set -- ;;
+        1) set -- "$args0" ;;
+        2) set -- "$args0" "$args1" ;;
+        3) set -- "$args0" "$args1" "$args2" ;;
+        4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=`save "$@"`
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+exec "$JAVACMD" "$@"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk11
+install:
+  - ./gradlew clean core:build activity:build fragment:build publishToMavenLocal


### PR DESCRIPTION
### What?

1. Rebuilt the gradle wrapper (which, for some reason, hadn't built correctly)
2. Added `jitpack.yml` file for specifying tasks to run when building the library
3. Added `withConsistentVersioning()` method and `fusionLibVersion` global property to root `build.gradle`
4. Added `maven-publish` plugins and publishing setup to `build.gradle` files for all library modules
5. Updated README.md with more complete details on installation
6. Replaced `project` imports with `jitpack` imports in the demo app, and resolved the _interesting_ issues caused by ViewBinding when a project imports itself

### Why?

1. Allows the JitPack build to run the gradle wrapper in order to build artifacts
2. Allows JitPack to build the artifacts correctly
3. Ensures that versioning is consistent with the core library, by forcing build failure if the dependency is not up to date
4. Ensures artifacts are specified to publish
5. Gives users of the library more info about how to use it
6. This was a fun one. The demo app should use JitPack imports, so that it is as close as possible to a representation of an actual Fusion app as possible. This doesn't cause circular dependencies, as the demo app module is not built by JitPack - it doesn't need to be built. _However_, it turns out that if you `<include />` a resource from an _internal_ module (i.e with `project()`, then `ViewBinding` generates the relevant sub-binding for the resource, but if you do the same thing for an _external_ module, then it just creates a property with type `View` for the include tag. _Furthermore_, because the actual source was in the same repo, the IDE thought that the members of the binding were sub-bindings _even if_ they were generated as `View`s, causing errors if I treated them as `View`s _or_ if I treated them as `ViewBinding`s. I tried importing the libs on a separate library and it correctly identified them as `View`s, so I then added the `@Suppress("TYPE_MISMATCH")` annotations, and this allowed me to build successfully.

### Testing

Tested by running the demo app successfully.