### PR TITLE
:NORMAL: Feature/updated view resolution

### DIFF
--- a/activity/src/main/java/com/cube/fusion/android/activity/FusionContentActivity.kt
+++ b/activity/src/main/java/com/cube/fusion/android/activity/FusionContentActivity.kt
@@ -88,10 +88,7 @@ abstract class FusionContentActivity : AppCompatActivity(), FusionDisplayTarget,
 
 	override fun displayPage(page: Page) {
 		if (!this::adapter.isInitialized) {
-			adapter = FusionViewAdapter().apply {
-				actionHandler = fusionConfig.actionHandler
-				imageLoader = fusionConfig.imageLoader
-			}
+			adapter = FusionViewAdapter(fusionConfig)
 			contentBinding.recyclerView.adapter = adapter
 			contentBinding.recyclerView.addItemDecoration(DropShadowDecorator())
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('feature~core-view-resolution-SNAPSHOT')
+	fusionLibVersion = withConsistentVersioning('develop-SNAPSHOT')
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('c7d04de47d')
+	fusionLibVersion = withConsistentVersioning('feature~core-view-resolution-SNAPSHOT')
 }
 
 task clean(type: Delete) {

--- a/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionConfig.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionConfig.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.android.core.config
 
 import com.cube.fusion.android.core.actions.FusionAndroidActionHandler
 import com.cube.fusion.android.core.images.FusionAndroidImageLoader
+import com.cube.fusion.android.core.resolver.AndroidViewResolver
 import com.cube.fusion.core.display.FusionDisplayPopulator
 
 /**
@@ -13,9 +14,11 @@ import com.cube.fusion.core.display.FusionDisplayPopulator
  * @param populator the config's display populator
  * @param actionHandler the config's action handler
  * @param imageLoader the config's image loader
+ * @param resolvers the map of class names to view resolvers to resolve views with
  */
 open class AndroidFusionConfig(
 	val populator: FusionDisplayPopulator,
 	val actionHandler: FusionAndroidActionHandler,
-	val imageLoader: FusionAndroidImageLoader?
+	val imageLoader: FusionAndroidImageLoader?,
+	val resolvers: MutableMap<String, AndroidViewResolver>
 )

--- a/core/src/main/java/com/cube/fusion/android/core/helper/ViewHelper.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/helper/ViewHelper.kt
@@ -15,7 +15,7 @@ import com.cube.fusion.core.model.views.*
  * Copyright ® 3SidedCube. All rights reserved.
  */
 object ViewHelper {
-	val viewResolvers: MutableMap<String, AndroidViewResolver> = hashMapOf(
+	fun getDefaultViewResolvers(): MutableMap<String, AndroidViewResolver> = hashMapOf(
 		"Screen" to DefaultViewResolver(Screen::class.java, null),
 		"Text" to DefaultViewResolver(Text::class.java, TextViewHolder.Factory::class.java),
 		"Image" to DefaultViewResolver(Image::class.java, ImageViewHolder.Factory::class.java),

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
@@ -1,7 +1,7 @@
 package com.cube.fusion.android.core.resolver
 
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
-import com.cube.fusion.core.model.Model
+import com.cube.fusion.core.resolver.ViewResolver
 
 /**
  * [ViewResolver] extension that pairs the View with a given fusion ViewHolder factory
@@ -9,7 +9,6 @@ import com.cube.fusion.core.model.Model
  * Created by Nikos Rapousis on 12/March/2021.
  * Copyright ® 3SidedCube. All rights reserved.
  */
-interface AndroidViewResolver {
-	fun resolveView(): Class<out Model?>?
+interface AndroidViewResolver : ViewResolver {
 	fun resolveViewHolder(): Class<out FusionViewHolderFactory?>?
 }

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "feature~jitpack-setup-SNAPSHOT"
+	def currentLibVersion = "feature~updated-view-resolution-SNAPSHOT"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 

--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 		  package="com.cube.fusion.android.demoapp">
 
+	<uses-permission android:name="android.permission.INTERNET" />
+
 	<application
 		android:allowBackup="true"
 		android:icon="@mipmap/ic_launcher"

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -10,8 +10,11 @@ import com.cube.fusion.android.core.config.AndroidFusionConfig
 import com.cube.fusion.android.core.databinding.ContentFragmentViewBinding
 import com.cube.fusion.android.core.databinding.ToolbarViewBinding
 import com.cube.fusion.android.core.helper.ViewHelper
+import com.cube.fusion.android.core.resolver.DefaultViewResolver
 import com.cube.fusion.android.demoapp.databinding.ActivityFusionImplBinding
+import com.cube.fusion.android.demoapp.holder.CardViewHolder
 import com.cube.fusion.android.demoapp.images.PicassoImageLoader
+import com.cube.fusion.android.demoapp.model.Card
 import com.cube.fusion.populator.legacy.LegacyDisplayPopulator
 
 /**
@@ -39,17 +42,23 @@ class ContentActivityImpl : FusionContentActivity() {
 	lateinit var binding: ActivityFusionImplBinding
 	override lateinit var contentBinding: ContentFragmentViewBinding
 	private lateinit var toolbarBinding: ToolbarViewBinding
-	override val fusionConfig: AndroidFusionConfig = AndroidFusionConfig(
-		populator = LegacyDisplayPopulator(ViewHelper.viewResolvers.values),
-		actionHandler = DefaultActivityActionHandlers { view, action ->
-			getIntent(view.context, action.extractClick())
-		}.apply {
-			registerNativeActionForLink(NATIVE_ACTION_KEY) { view, _ ->
-				view.context.startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
-			}
-		},
-		imageLoader = PicassoImageLoader
-	)
+	override val fusionConfig: AndroidFusionConfig = run {
+		val resolvers = ViewHelper.getDefaultViewResolvers().apply {
+			put("Card", DefaultViewResolver(Card::class.java, CardViewHolder.Factory::class.java))
+		}
+		AndroidFusionConfig(
+			populator = LegacyDisplayPopulator(resolvers.values),
+			actionHandler = DefaultActivityActionHandlers { view, action ->
+				getIntent(view.context, action.extractClick())
+			}.apply {
+				registerNativeActionForLink(NATIVE_ACTION_KEY) { view, _ ->
+					view.context.startActivity(Intent(Settings.ACTION_WIFI_SETTINGS))
+				}
+			},
+			imageLoader = PicassoImageLoader,
+			resolvers = resolvers
+		)
+	}
 
 	override fun setTitle(title: CharSequence?) {
 		super.setTitle(title)

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -40,7 +40,7 @@ class ContentActivityImpl : FusionContentActivity() {
 	override lateinit var contentBinding: ContentFragmentViewBinding
 	private lateinit var toolbarBinding: ToolbarViewBinding
 	override val fusionConfig: AndroidFusionConfig = AndroidFusionConfig(
-		populator = LegacyDisplayPopulator,
+		populator = LegacyDisplayPopulator(ViewHelper.viewResolvers.values),
 		actionHandler = DefaultActivityActionHandlers { view, action ->
 			getIntent(view.context, action.extractClick())
 		}.apply {

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/FusionContentFragment.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/FusionContentFragment.kt
@@ -56,10 +56,7 @@ class FusionContentFragment(private val fusionConfig: AndroidFusionConfig) : Fra
 			displayError(EmptyUrlError())
 		}
 		else {
-			adapter = FusionViewAdapter().apply {
-				actionHandler = fusionConfig.actionHandler
-				imageLoader = fusionConfig.imageLoader
-			}
+			adapter = FusionViewAdapter(fusionConfig)
 			binding.recyclerView.adapter = adapter
 			binding.recyclerView.addItemDecoration(DropShadowDecorator())
 			loadPages(url)

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentManager
 import com.cube.fusion.android.activity.actions.DefaultActivityActionHandlers
 import com.cube.fusion.android.core.databinding.ContentActivityViewBinding
 import com.cube.fusion.android.core.config.AndroidFusionConfig
+import com.cube.fusion.android.core.helper.ViewHelper
 import com.cube.fusion.android.core.images.ImageLoadingManager
 import com.cube.fusion.android.fragment.FusionContentFragment
 import com.cube.fusion.android.fragment.R
@@ -29,7 +30,7 @@ class LegacyContentActivity : AppCompatActivity() {
 
 	private lateinit var binding: ContentActivityViewBinding
 	private val fusionConfig = AndroidFusionConfig(
-		populator = LegacyDisplayPopulator,
+		populator = LegacyDisplayPopulator(ViewHelper.viewResolvers.values),
 		actionHandler = DefaultActivityActionHandlers(LegacyContentActivity::class.java),
 		imageLoader = ImageLoadingManager.imageLoader
 	)

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
@@ -30,10 +30,10 @@ class LegacyContentActivity : AppCompatActivity() {
 
 	private lateinit var binding: ContentActivityViewBinding
 	private val fusionConfig = AndroidFusionConfig(
-		populator = LegacyDisplayPopulator(ViewHelper.viewResolvers.values),
+		populator = LegacyDisplayPopulator(ViewHelper.getDefaultViewResolvers().values),
 		actionHandler = DefaultActivityActionHandlers(LegacyContentActivity::class.java),
 		imageLoader = ImageLoadingManager.imageLoader,
-		resolvers = ViewHelper.viewResolvers
+		resolvers = ViewHelper.getDefaultViewResolvers()
 	)
 	private val fragmentFactory = FusionContentFragmentFactory(fusionConfig)
 	override fun onCreate(savedInstanceState: Bundle?) {

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
@@ -32,7 +32,8 @@ class LegacyContentActivity : AppCompatActivity() {
 	private val fusionConfig = AndroidFusionConfig(
 		populator = LegacyDisplayPopulator(ViewHelper.viewResolvers.values),
 		actionHandler = DefaultActivityActionHandlers(LegacyContentActivity::class.java),
-		imageLoader = ImageLoadingManager.imageLoader
+		imageLoader = ImageLoadingManager.imageLoader,
+		resolvers = ViewHelper.viewResolvers
 	)
 	private val fragmentFactory = FusionContentFragmentFactory(fusionConfig)
 	override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
### What?
- Updated targeted versions of the relevant Fusion libs
- Added internet permission to the demo app's manifest
- Added the `resolvers` property to `AndroidFusionConfig`, using everywhere necessary
- Updated `FusionViewAdapter` to:
  - move body `var` properties to the constructor
  - add `resolvers` property to the constructor
  - add / update constructors to permit construction from an `AndroidFusionConfig` instance
  - use `resolvers` property in place of `ViewHelper.viewResolvers` to resolve views
- Replaced singleton property `ViewHelper.viewResolvers` with a method `ViewHelper.getDefaultViewResolvers()`
- Updated calls to `LegacyViewPopulator` to provide the constructor param
- Updated the demo app's `ContentActivityImpl` activity to use the new patterns defined by above, and to register the `Card` custom view
### Why?
This brings the AndroidUi lib in line with the new behaviour of the Core lib, and ensures that custom views can be easily registered and scoped.
Also, the internet permission change was needed in order to successfully load data to the demo app.
### Screenshots / screen recordings
Below video shows walking through a few pages in the demo app from this repo, with the base and page URL configured to an internal API.

https://user-images.githubusercontent.com/8377714/157052409-a5ab1fd7-6102-40e9-bfd0-174affb6f9b2.mp4
### Testing
Clone the repo, update the URLs in `MainActivity` to point to a valid Fusion data source, and then run the demo app.
### Anything else?
You may notice a couple of things that look slightly off in the screen recording, notably:
- Chevrons have been replaced with the Android icon
- The top bar has lost most of its formatting and components

These are artifacts of WIP reworking the library so that its UI is more flexible.
I might make a few small changes to the demo app to make it look nicer, but ultimately these are things that can be resolved in any app utilising this library.

