### PR TITLE
:LOW: Feature/demo fusion pages

### DIFF
--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -47,7 +47,8 @@ dependencies {
 
 	// Fusion dependencies - specify version in the root build.gradle
 	implementation "com.github.3sidedcube.Android-Fusion-Core:core:${project.fusionLibVersion}"
-	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
+	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-coroutine-source-cache:${project.fusionLibVersion}"
+	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-retrofit:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
 	def currentLibVersion = "v0.0.2-rc2"

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-legacy:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "feature~updated-view-resolution-SNAPSHOT"
+	def currentLibVersion = "v0.0.2-rc2"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 

--- a/demoapp/src/main/assets/root.json
+++ b/demoapp/src/main/assets/root.json
@@ -1,0 +1,63 @@
+{
+	"id": "root",
+	"title": "Fusion AndroidUi Demo App",
+	"screen": {
+		"class": "Screen",
+		"children": [
+			{
+				"class": "Text",
+				"content": "Welcome to the Fusion AndroidUi Demo App!",
+				"margin": {
+					"left": 5,
+					"right": 5,
+					"top": 5,
+					"bottom": 5
+				},
+				"font": {
+					"size": 22
+				},
+				"text_alignment": "center"
+			},
+			{
+				"class": "ListItem",
+				"title": {
+					"class": "Text",
+					"content": "Page redirect",
+					"font": {
+						"size": 17
+					}
+				},
+				"subtitle": {
+					"class": "Text",
+					"content": "Click here to redirect to a second page!",
+					"font": {
+						"size": 14
+					}
+				},
+				"action": {
+					"class": "PageAction",
+					"entry": {
+						"api_url": "second.json"
+					}
+				},
+				"margin": {
+					"left": 5,
+					"right": 5,
+					"top": 5,
+					"bottom": 5
+				},
+				"padding": {
+					"left": 5,
+					"right": 5,
+					"top": 5,
+					"bottom": 5
+				},
+				"border": {
+					"stroke_width": 1,
+					"color": "#ABABAB"
+				},
+				"corner_radius": 3
+			}
+		]
+	}
+}

--- a/demoapp/src/main/assets/second.json
+++ b/demoapp/src/main/assets/second.json
@@ -1,0 +1,23 @@
+{
+	"id": "second",
+	"title": "Fusion AndroidUi Demo App - Second Page",
+	"screen": {
+		"class": "Screen",
+		"children": [
+			{
+				"class": "Text",
+				"content": "This is the second page of demo app content!",
+				"margin": {
+					"left": 5,
+					"right": 5,
+					"top": 5,
+					"bottom": 5
+				},
+				"font": {
+					"size": 22
+				},
+				"text_alignment": "center"
+			}
+		]
+	}
+}

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -16,6 +16,7 @@ import com.cube.fusion.android.demoapp.databinding.ActivityFusionImplBinding
 import com.cube.fusion.android.demoapp.holder.CardViewHolder
 import com.cube.fusion.android.demoapp.images.PicassoImageLoader
 import com.cube.fusion.android.demoapp.model.Card
+import com.cube.fusion.populator.coroutinesourcecache.source.AssetsPageSource
 import com.cube.fusion.populator.retrofit.RetrofitDisplayPopulator
 
 /**
@@ -53,8 +54,9 @@ class ContentActivityImpl : FusionContentActivity() {
 		val resolvers = ViewHelper.getDefaultViewResolvers().apply {
 			put("Card", DefaultViewResolver(Card::class.java, CardViewHolder.Factory::class.java))
 		}
+		val localSource = AssetsPageSource(this, { it }, resolvers.values)
 		return AndroidFusionConfig(
-			populator = RetrofitDisplayPopulator(this::lifecycleScope, baseUrl, resolvers.values),
+			populator = RetrofitDisplayPopulator(this::lifecycleScope, baseUrl, resolvers.values, localSource),
 			actionHandler = DefaultActivityActionHandlers { view, action ->
 				getIntent(view.context, baseUrl, action.extractClick())
 			}.apply {

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
@@ -15,10 +15,10 @@ import kotlinx.coroutines.launch
  */
 class MainActivity : AppCompatActivity() {
 	companion object {
-	   /*
-		* These currently point to the locally defined demo JSON data in the most recent release of this lib
-		* Feel free to locally update this URL and start screen to your own endpoints if you wish
-		*/
+		/*
+		 * These currently point to the locally defined demo JSON data in the most recent release of this lib
+		 * Feel free to locally update this URL and start screen to your own endpoints if you wish
+		 */
 		private const val DEMO_URL = "https://raw.githubusercontent.com/3sidedcube/Android-Fusion-AndroidUi/main/demoapp/src/main/assets/"
 		private const val START_SCREEN = "root.json"
 	}

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
@@ -15,8 +15,12 @@ import kotlinx.coroutines.launch
  */
 class MainActivity : AppCompatActivity() {
 	companion object {
-		private const val DEMO_URL = "Put your URL here!"
-		private const val START_SCREEN = "Put your starting screen slug/URL here!"
+	   /*
+		* These currently point to the locally defined demo JSON data in the most recent release of this lib
+		* Feel free to locally update this URL and start screen to your own endpoints if you wish
+		*/
+		private const val DEMO_URL = "https://raw.githubusercontent.com/3sidedcube/Android-Fusion-AndroidUi/main/demoapp/src/main/assets/"
+		private const val START_SCREEN = "root.json"
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.cube.fusion.android.demoapp.R
-import com.cube.fusion.populator.legacy.api.APIFactory
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -27,11 +26,8 @@ class MainActivity : AppCompatActivity() {
 			// Display for 1 seconds
 			delay(1000)
 
-			// Set up the legacy API factory
-			APIFactory.url = DEMO_URL
-
 			// Redirect to the content activity
-			val intent = ContentActivityImpl.getIntent(baseContext, START_SCREEN)
+			val intent = ContentActivityImpl.getIntent(baseContext, DEMO_URL, START_SCREEN)
 			startActivity(intent)
 
 			// Close this activity

--- a/demoapp/src/main/res/values-night/themes.xml
+++ b/demoapp/src/main/res/values-night/themes.xml
@@ -12,6 +12,6 @@
 		<!-- Status bar color. -->
 		<item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
 		<!-- Customize your theme here. -->
-		<item name="fusionListItemChevron">@drawable/ic_launcher_foreground</item>
+		<item name="fusionListItemChevron">@android:drawable/ic_media_play</item>
 	</style>
 </resources>

--- a/demoapp/src/main/res/values/themes.xml
+++ b/demoapp/src/main/res/values/themes.xml
@@ -12,6 +12,6 @@
 		<!-- Status bar color. -->
 		<item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
 		<!-- Customize your theme here. -->
-		<item name="fusionListItemChevron">@drawable/ic_launcher_foreground</item>
+		<item name="fusionListItemChevron">@android:drawable/ic_media_play</item>
 	</style>
 </resources>


### PR DESCRIPTION
### What?
Exclusively changes to the demo app:
- Replaced the demo app chevron with android play media drawable
- Updated `ContentActivityImpl` so that it is passed the API base URL via an intent extras
- Updated the required lib version to `v0.0.2-rc2`
- Removed the dependency on the legacy populator, and replaced with the dependencies for the retrofit and coroutine source cache populators
- Updated `ContentActivityImpl` to use the Retrofit populator, and fall back on local assets
- Added two sparse JSON Page data files to the demo app's `assets` directory
- Updated the base URL and start screen to point to the most up-to-date `main` branch demo app `assets` directory
### Why?
Updates the demo to be in line with the `Core` `v0.0.2-rc2` release, improving the demo app so that:
- it actually has some content to show
- it relies less upon legacy Fusion implementations
- it can run without internet connection
### Screen recordings
Attached screen recording shows interacting with the demo app

https://user-images.githubusercontent.com/8377714/159505784-0c200347-80d7-452c-947d-75059f3b62aa.mp4