### PR TITLE
Feature/data preprocessing step

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('8b12af27a4')
+	fusionLibVersion = withConsistentVersioning('v0.0.4-rc4')
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('v0.0.3')
+	fusionLibVersion = withConsistentVersioning('03ffb618a9')
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('v0.0.4-rc1')
+	fusionLibVersion = withConsistentVersioning('8b12af27a4')
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('03ffb618a9')
+	fusionLibVersion = withConsistentVersioning('v0.0.4-rc1')
 }
 
 task clean(type: Delete) {

--- a/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionViewConfig.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionViewConfig.kt
@@ -2,7 +2,7 @@ package com.cube.fusion.android.core.config
 
 import com.cube.fusion.android.core.actions.FusionAndroidActionHandler
 import com.cube.fusion.android.core.images.FusionAndroidImageLoader
-import com.cube.fusion.core.processor.FusionDataPreprocessor
+import com.cube.fusion.core.processor.FusionDataPreprocessorCollection
 
 /**
  * Convenience class for storing configuration objects needed by ViewHolders in a Fusion Android setup
@@ -12,10 +12,10 @@ import com.cube.fusion.core.processor.FusionDataPreprocessor
  *
  * @param actionHandler The config's action handler
  * @param imageLoader The config's image loader
- * @param preprocessors A list of pre-processors to use to process data directly before populating the ViewHolder UI
+ * @param preprocessors The collection of pre-processors to use to process data directly before populating the ViewHolder UI
  */
 class AndroidFusionViewConfig(
 	val actionHandler: FusionAndroidActionHandler,
 	val imageLoader: FusionAndroidImageLoader?,
-	val preprocessors: List<FusionDataPreprocessor<*>>
+	val preprocessors: FusionDataPreprocessorCollection
 )

--- a/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionViewConfig.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/config/AndroidFusionViewConfig.kt
@@ -2,6 +2,7 @@ package com.cube.fusion.android.core.config
 
 import com.cube.fusion.android.core.actions.FusionAndroidActionHandler
 import com.cube.fusion.android.core.images.FusionAndroidImageLoader
+import com.cube.fusion.core.processor.FusionDataPreprocessor
 
 /**
  * Convenience class for storing configuration objects needed by ViewHolders in a Fusion Android setup
@@ -11,8 +12,10 @@ import com.cube.fusion.android.core.images.FusionAndroidImageLoader
  *
  * @param actionHandler The config's action handler
  * @param imageLoader The config's image loader
+ * @param preprocessors A list of pre-processors to use to process data directly before populating the ViewHolder UI
  */
 class AndroidFusionViewConfig(
 	val actionHandler: FusionAndroidActionHandler,
-	val imageLoader: FusionAndroidImageLoader?
+	val imageLoader: FusionAndroidImageLoader?,
+	val preprocessors: List<FusionDataPreprocessor<*>>
 )

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
@@ -12,6 +12,7 @@ import com.cube.fusion.android.core.databinding.BulletGroupViewBinding
 import com.cube.fusion.android.core.databinding.BulletViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.BulletGroup
 
 /**
@@ -66,10 +67,11 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 		}
 
 		populateBaseView(
-			binding.root,
-			model.baseProperties,
-			R.color.fusion_default_bullet_group_view_background_colour,
-			R.dimen.fusion_default_bullet_group_view_corner_radius
+			cardView = binding.root,
+			unprocessedProperties = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = R.color.fusion_default_bullet_group_view_background_colour,
+			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_group_view_corner_radius
 		)
 
 		//Apply padding

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
@@ -14,6 +14,7 @@ import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.BulletGroup
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [BulletGroup] view
@@ -44,13 +45,16 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 	}
 
 	override fun populateView(unprocessedModel: BulletGroup) {
+		// Data preprocessing
+		val model = viewConfig.preprocessors.filterIsInstance<BulletGroup.Preprocessor>().preprocess(unprocessedModel)
+		
 		val context = itemView.context
 		binding.root.unregisterAllChildViewHolders()
 		binding.bulletGroupContainer.removeAllViews()
 
-		delegate.count = unprocessedModel.children.size
+		delegate.count = model.children.size
 
-		for (index in 0 until unprocessedModel.children.size) {
+		for (index in 0 until model.children.size) {
 			val annotateView = BulletViewHolder(
 				BulletViewBinding.inflate(
 					LayoutInflater.from(context),
@@ -59,7 +63,7 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 				),
 				viewConfig
 			)
-			val annotation = unprocessedModel.children[index]
+			val annotation = model.children[index]
 			annotation.order = index + 1
 			annotateView.populateViewFromModel(annotation)
 			binding.bulletGroupContainer.addView(annotateView.itemView)
@@ -68,13 +72,13 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 
 		populateBaseView(
 			cardView = binding.root,
-			unprocessedProperties = unprocessedModel.baseProperties,
+			unprocessedProperties = model.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_group_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_group_view_corner_radius
 		)
 
 		//Apply padding
-		binding.bulletGroupContainer.setPadding(unprocessedModel.baseProperties.padding)
+		binding.bulletGroupContainer.setPadding(model.baseProperties.padding)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
@@ -43,14 +43,14 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 		}
 	}
 
-	override fun populateView(model: BulletGroup) {
+	override fun populateView(unprocessedModel: BulletGroup) {
 		val context = itemView.context
 		binding.root.unregisterAllChildViewHolders()
 		binding.bulletGroupContainer.removeAllViews()
 
-		delegate.count = model.children.size
+		delegate.count = unprocessedModel.children.size
 
-		for (index in 0 until model.children.size) {
+		for (index in 0 until unprocessedModel.children.size) {
 			val annotateView = BulletViewHolder(
 				BulletViewBinding.inflate(
 					LayoutInflater.from(context),
@@ -59,7 +59,7 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 				),
 				viewConfig
 			)
-			val annotation = model.children[index]
+			val annotation = unprocessedModel.children[index]
 			annotation.order = index + 1
 			annotateView.populateViewFromModel(annotation)
 			binding.bulletGroupContainer.addView(annotateView.itemView)
@@ -68,13 +68,13 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 
 		populateBaseView(
 			cardView = binding.root,
-			unprocessedProperties = model.baseProperties,
+			unprocessedProperties = unprocessedModel.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_group_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_group_view_corner_radius
 		)
 
 		//Apply padding
-		binding.bulletGroupContainer.setPadding(model.baseProperties.padding)
+		binding.bulletGroupContainer.setPadding(unprocessedModel.baseProperties.padding)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
@@ -12,9 +12,7 @@ import com.cube.fusion.android.core.databinding.BulletGroupViewBinding
 import com.cube.fusion.android.core.databinding.BulletViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.BulletGroup
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [BulletGroup] view
@@ -46,7 +44,7 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 
 	override fun populateView(unprocessedModel: BulletGroup) {
 		// Data preprocessing
-		val model = viewConfig.preprocessors.filterIsInstance<BulletGroup.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(BulletGroup::class, unprocessedModel)
 		
 		val context = itemView.context
 		binding.root.unregisterAllChildViewHolders()
@@ -73,7 +71,7 @@ class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: And
 		populateBaseView(
 			cardView = binding.root,
 			unprocessedProperties = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_group_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_group_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
@@ -52,22 +52,22 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 		}
 	}
 
-	override fun populateView(model: Bullet) {
-		titleViewHolder.populateChildView(model.title)
-		subtitleViewHolder.populateChildView(model.subtitle)
+	override fun populateView(unprocessedModel: Bullet) {
+		titleViewHolder.populateChildView(unprocessedModel.title)
+		subtitleViewHolder.populateChildView(unprocessedModel.subtitle)
 
-		binding.order.text = model.order.toString()
-		delegate.model = model
+		binding.order.text = unprocessedModel.order.toString()
+		delegate.model = unprocessedModel
 
 		populateBaseView(
 			cardView = binding.cardContainer,
-			unprocessedProperties = model.baseProperties,
+			unprocessedProperties = unprocessedModel.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_view_corner_radius
 		)
 
 		//Apply padding
-		binding.bulletViewContainer.setPadding(model.baseProperties.padding)
+		binding.bulletViewContainer.setPadding(unprocessedModel.baseProperties.padding)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
@@ -13,6 +13,7 @@ import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Bullet
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Bullet] view
@@ -53,21 +54,24 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 	}
 
 	override fun populateView(unprocessedModel: Bullet) {
-		titleViewHolder.populateChildView(unprocessedModel.title)
-		subtitleViewHolder.populateChildView(unprocessedModel.subtitle)
+		// Data preprocessing
+		val model = viewConfig.preprocessors.filterIsInstance<Bullet.Preprocessor>().preprocess(unprocessedModel)
+		
+		titleViewHolder.populateChildView(model.title)
+		subtitleViewHolder.populateChildView(model.subtitle)
 
-		binding.order.text = unprocessedModel.order.toString()
-		delegate.model = unprocessedModel
+		binding.order.text = model.order.toString()
+		delegate.model = model
 
 		populateBaseView(
 			cardView = binding.cardContainer,
-			unprocessedProperties = unprocessedModel.baseProperties,
+			unprocessedProperties = model.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_view_corner_radius
 		)
 
 		//Apply padding
-		binding.bulletViewContainer.setPadding(unprocessedModel.baseProperties.padding)
+		binding.bulletViewContainer.setPadding(model.baseProperties.padding)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
@@ -11,6 +11,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.BulletViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Bullet
 
 /**
@@ -59,10 +60,11 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 		delegate.model = model
 
 		populateBaseView(
-			binding.cardContainer,
-			model.baseProperties,
-			R.color.fusion_default_bullet_view_background_colour,
-			R.dimen.fusion_default_bullet_view_corner_radius
+			cardView = binding.cardContainer,
+			unprocessedProperties = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = R.color.fusion_default_bullet_view_background_colour,
+			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_view_corner_radius
 		)
 
 		//Apply padding

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
@@ -11,9 +11,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.BulletViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Bullet
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Bullet] view
@@ -55,7 +53,7 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 
 	override fun populateView(unprocessedModel: Bullet) {
 		// Data preprocessing
-		val model = viewConfig.preprocessors.filterIsInstance<Bullet.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(Bullet::class, unprocessedModel)
 		
 		titleViewHolder.populateChildView(model.title)
 		subtitleViewHolder.populateChildView(model.subtitle)
@@ -66,7 +64,7 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 		populateBaseView(
 			cardView = binding.cardContainer,
 			unprocessedProperties = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = R.color.fusion_default_bullet_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_bullet_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
@@ -9,6 +9,8 @@ import com.cube.fusion.android.core.databinding.TextViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Button
+import com.cube.fusion.core.model.views.Text
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Button] view
@@ -25,9 +27,13 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 	}
 
 	override fun populateView(unprocessedModel: Button) {
+		// Data preprocessing
+		val model = viewConfig.preprocessors.filterIsInstance<Button.Preprocessor>().preprocess(unprocessedModel)
+
 		TextViewHolder.populateView(
 			textView = binding.text,
-			textModel = unprocessedModel.baseProperties,
+			unprocessedModel = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>(),
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -35,18 +41,22 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			unprocessedProperties = unprocessedModel.baseProperties.baseProperties,
+			unprocessedProperties = model.baseProperties.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_button_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
-		populateClickHandler(unprocessedModel)
+		populateClickHandler(model)
 	}
 
 	override fun populateChildView(unprocessedModel: Button?) {
+		// Data preprocessing
+		val model = unprocessedModel?.let { viewConfig.preprocessors.filterIsInstance<Button.Preprocessor>().preprocess(it) }
+
 		TextViewHolder.populateView(
 			textView = binding.text,
-			textModel = unprocessedModel?.baseProperties,
+			unprocessedModel = model?.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>(),
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -54,12 +64,12 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			unprocessedProperties = unprocessedModel?.baseProperties?.baseProperties,
+			unprocessedProperties = model?.baseProperties?.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = android.R.color.transparent,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
-		populateClickHandler(unprocessedModel)
+		populateClickHandler(model)
 	}
 
 	private fun populateClickHandler(model: Button?) {

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
@@ -7,6 +7,7 @@ import com.cube.fusion.android.core.R
 import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.TextViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Button
 
 /**
@@ -34,7 +35,8 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			baseProperties = model.baseProperties.baseProperties,
+			unprocessedProperties = model.baseProperties.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_button_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
@@ -52,7 +54,8 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			baseProperties = model?.baseProperties?.baseProperties,
+			unprocessedProperties = model?.baseProperties?.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = android.R.color.transparent,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
@@ -7,10 +7,7 @@ import com.cube.fusion.android.core.R
 import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.TextViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Button
-import com.cube.fusion.core.model.views.Text
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Button] view
@@ -28,12 +25,12 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 
 	override fun populateView(unprocessedModel: Button) {
 		// Data preprocessing
-		val model = viewConfig.preprocessors.filterIsInstance<Button.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(Button::class, unprocessedModel)
 
 		TextViewHolder.populateView(
 			textView = binding.text,
 			unprocessedModel = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -42,7 +39,7 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		populateBaseView(
 			cardView = binding.textContainer,
 			unprocessedProperties = model.baseProperties.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = R.color.fusion_default_button_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
@@ -51,12 +48,12 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 
 	override fun populateChildView(unprocessedModel: Button?) {
 		// Data preprocessing
-		val model = unprocessedModel?.let { viewConfig.preprocessors.filterIsInstance<Button.Preprocessor>().preprocess(it) }
+		val model = unprocessedModel?.let { viewConfig.preprocessors.preprocess(Button::class, it) }
 
 		TextViewHolder.populateView(
 			textView = binding.text,
 			unprocessedModel = model?.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -65,7 +62,7 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		populateBaseView(
 			cardView = binding.textContainer,
 			unprocessedProperties = model?.baseProperties?.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = android.R.color.transparent,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
@@ -24,10 +24,10 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		}
 	}
 
-	override fun populateView(model: Button) {
+	override fun populateView(unprocessedModel: Button) {
 		TextViewHolder.populateView(
 			textView = binding.text,
-			textModel = model.baseProperties,
+			textModel = unprocessedModel.baseProperties,
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -35,18 +35,18 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			unprocessedProperties = model.baseProperties.baseProperties,
+			unprocessedProperties = unprocessedModel.baseProperties.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_button_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
-		populateClickHandler(model)
+		populateClickHandler(unprocessedModel)
 	}
 
-	override fun populateChildView(model: Button?) {
+	override fun populateChildView(unprocessedModel: Button?) {
 		TextViewHolder.populateView(
 			textView = binding.text,
-			textModel = model?.baseProperties,
+			textModel = unprocessedModel?.baseProperties,
 			defaultTextSize = R.dimen.fusion_default_button_view_text_size,
 			defaultTextColour = R.color.fusion_default_button_view_text_colour,
 			defaultLetterSpacing = R.dimen.fusion_default_button_view_letter_spacing,
@@ -54,12 +54,12 @@ class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionVi
 		)
 		populateBaseView(
 			cardView = binding.textContainer,
-			unprocessedProperties = model?.baseProperties?.baseProperties,
+			unprocessedProperties = unprocessedModel?.baseProperties?.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = android.R.color.transparent,
 			defaultCornerRadiusResId = R.dimen.fusion_default_button_view_corner_radius
 		)
-		populateClickHandler(model)
+		populateClickHandler(unprocessedModel)
 	}
 
 	private fun populateClickHandler(model: Button?) {

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ChildViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ChildViewHolder.kt
@@ -12,11 +12,11 @@ import com.cube.fusion.core.model.Model
  */
 abstract class ChildViewHolder<T : Model>(itemView: View, viewConfig: AndroidFusionViewConfig) : FusionViewHolder<T>(itemView, viewConfig) {
 	/**
-	 * Updates the UI of the view based on a nullable [model] of type [T]
+	 * Updates the UI of the view based on a nullable [unprocessedModel] of type [T]
 	 * Should behave as similarly to [populateView] as possible, however, there may be cases (such as with background colour) where behaviour should differ
 	 *
-	 * @param model the model to update UI from, or null
+	 * @param unprocessedModel The unprocessed model to update UI from, or null
 	 *  if null, should set the view to its default UI state
 	 */
-	abstract fun populateChildView(model: T?)
+	abstract fun populateChildView(unprocessedModel: T?)
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
@@ -8,6 +8,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.DividerViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.extensions.dpToPx
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Divider
 import kotlin.math.ceil
 import kotlin.math.roundToInt
@@ -42,10 +43,11 @@ class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: And
 		binding.divider.layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, ceil(height + verticalPadding).roundToInt())
 
 		populateBaseView(
-			binding.divider,
-			model.baseProperties,
-			R.color.fusion_default_divider_view_background_colour,
-			R.dimen.fusion_default_divider_view_corner_radius
+			cardView = binding.divider,
+			unprocessedProperties = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = R.color.fusion_default_divider_view_background_colour,
+			defaultCornerRadiusResId = R.dimen.fusion_default_divider_view_corner_radius
 		)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
@@ -8,9 +8,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.DividerViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.extensions.dpToPx
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Divider
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -36,7 +34,7 @@ class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: And
 	 */
 	override fun populateView(unprocessedModel: Divider) {
 		// Data preprocessing
-		val model = viewConfig.preprocessors.filterIsInstance<Divider.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(Divider::class, unprocessedModel)
 		
 		val height = model.strokeWidth?.let {
 			itemView.resources.dpToPx(it)
@@ -49,7 +47,7 @@ class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: And
 		populateBaseView(
 			cardView = binding.divider,
 			unprocessedProperties = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = R.color.fusion_default_divider_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_divider_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
@@ -10,6 +10,7 @@ import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.extensions.dpToPx
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Divider
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -34,17 +35,20 @@ class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: And
 	 * 	since width is MATCH_PARENT, horizontal padding would do nothing, but vertical padding would increase container size
 	 */
 	override fun populateView(unprocessedModel: Divider) {
-		val height = unprocessedModel.strokeWidth?.let {
+		// Data preprocessing
+		val model = viewConfig.preprocessors.filterIsInstance<Divider.Preprocessor>().preprocess(unprocessedModel)
+		
+		val height = model.strokeWidth?.let {
 			itemView.resources.dpToPx(it)
 		} ?: itemView.resources.getDimension(R.dimen.fusion_default_divider_height)
-		val verticalPadding = unprocessedModel.baseProperties.padding?.let {
+		val verticalPadding = model.baseProperties.padding?.let {
 			itemView.resources.dpToPx(it.top + it.bottom)
 		} ?: itemView.resources.let { it.getDimension(R.dimen.fusion_default_padding_top) + it.getDimension(R.dimen.fusion_default_padding_bottom) }
 		binding.divider.layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, ceil(height + verticalPadding).roundToInt())
 
 		populateBaseView(
 			cardView = binding.divider,
-			unprocessedProperties = unprocessedModel.baseProperties,
+			unprocessedProperties = model.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_divider_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_divider_view_corner_radius

--- a/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
@@ -33,18 +33,18 @@ class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: And
 	 * This is equivalent to if there was a zero-size view in the middle and the specified amount of padding -
 	 * 	since width is MATCH_PARENT, horizontal padding would do nothing, but vertical padding would increase container size
 	 */
-	override fun populateView(model: Divider) {
-		val height = model.strokeWidth?.let {
+	override fun populateView(unprocessedModel: Divider) {
+		val height = unprocessedModel.strokeWidth?.let {
 			itemView.resources.dpToPx(it)
 		} ?: itemView.resources.getDimension(R.dimen.fusion_default_divider_height)
-		val verticalPadding = model.baseProperties.padding?.let {
+		val verticalPadding = unprocessedModel.baseProperties.padding?.let {
 			itemView.resources.dpToPx(it.top + it.bottom)
 		} ?: itemView.resources.let { it.getDimension(R.dimen.fusion_default_padding_top) + it.getDimension(R.dimen.fusion_default_padding_bottom) }
 		binding.divider.layoutParams = RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, ceil(height + verticalPadding).roundToInt())
 
 		populateBaseView(
 			cardView = binding.divider,
-			unprocessedProperties = model.baseProperties,
+			unprocessedProperties = unprocessedModel.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_divider_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_divider_view_corner_radius

--- a/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
@@ -20,7 +20,7 @@ import com.cube.fusion.android.core.utils.shadow.ShadowRectSpec
 import com.cube.fusion.core.model.Margin
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.views.BaseViewProperties
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
+import com.cube.fusion.core.processor.FusionDataPreprocessorCollection
 import com.google.android.material.card.MaterialCardView
 import kotlin.math.ceil
 import kotlin.math.roundToInt
@@ -74,12 +74,12 @@ abstract class FusionViewHolder<T : Model>(itemView: View, protected val viewCon
 	protected fun populateBaseView(
 		cardView: MaterialCardView,
 		unprocessedProperties: BaseViewProperties?,
-		preprocessors: List<BaseViewProperties.Preprocessor>,
+		preprocessors: FusionDataPreprocessorCollection,
 		@ColorRes defaultBackgroundColourResId: Int,
 		@DimenRes defaultCornerRadiusResId: Int
 	) {
 		// Data preprocessing
-		val baseProperties = unprocessedProperties?.let { preprocessors.preprocess(it) }
+		val baseProperties = unprocessedProperties?.let { preprocessors.preprocess(BaseViewProperties::class, it) }
 
 		val theme = cardView.context.theme
 		val resources = cardView.resources

--- a/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
@@ -39,15 +39,15 @@ abstract class FusionViewHolder<T : Model>(itemView: View, protected val viewCon
 	 * Called when the view needs to be populated
 	 * Note: unchecked cast from Model to T; should never cause issues provided all registered Views are named and registered correctly.
 	 *
-	 * @param model The model to populate the view with
+	 * @param unprocessedModel The unprocessed model to populate the view with
 	 */
 	@Suppress("UNCHECKED_CAST")
-	fun populateViewFromModel(model: Model) = populateView(model as T)
+	fun populateViewFromModel(unprocessedModel: Model) = populateView(unprocessedModel as T)
 
 	/**
-	 * Updates the UI of the view based on a [model] of type [T]
+	 * Updates the UI of the view based on a [unprocessedModel] of type [T]
 	 */
-	protected abstract fun populateView(model: T)
+	protected abstract fun populateView(unprocessedModel: T)
 
 	override var shadowRectSpec: List<ShadowRectSpec>? = null
 		protected set

--- a/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/FusionViewHolder.kt
@@ -20,6 +20,7 @@ import com.cube.fusion.android.core.utils.shadow.ShadowRectSpec
 import com.cube.fusion.core.model.Margin
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.views.BaseViewProperties
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 import com.google.android.material.card.MaterialCardView
 import kotlin.math.ceil
 import kotlin.math.roundToInt
@@ -64,17 +65,22 @@ abstract class FusionViewHolder<T : Model>(itemView: View, protected val viewCon
 	 * Does not handle padding, as this is strongly coupled with the particular view implementation (e.g the content it holds)
 	 * Padding should therefore be handled separately in the [populateView] method
 	 *
-	 * @param cardView the base [MaterialCardView] that the view is built upon
-	 * @param baseProperties the base view properties to populate the base UI with, or null - if null, uses all defaults
-	 * @param defaultBackgroundColourResId the resource ID for the default background colour of this view
-	 * @param defaultCornerRadiusResId the resource ID for the default corner radius of this view
+	 * @param cardView The base [MaterialCardView] that the view is built upon
+	 * @param unprocessedProperties The unprocessed base view properties to populate the base UI with, or null - if null, uses all defaults
+	 * @param preprocessors A list of pre-processing steps to apply to the unprocessed base properties before populating UI
+	 * @param defaultBackgroundColourResId The resource ID for the default background colour of this view
+	 * @param defaultCornerRadiusResId The resource ID for the default corner radius of this view
 	 */
 	protected fun populateBaseView(
 		cardView: MaterialCardView,
-		baseProperties: BaseViewProperties?,
+		unprocessedProperties: BaseViewProperties?,
+		preprocessors: List<BaseViewProperties.Preprocessor>,
 		@ColorRes defaultBackgroundColourResId: Int,
 		@DimenRes defaultCornerRadiusResId: Int
 	) {
+		// Data preprocessing
+		val baseProperties = unprocessedProperties?.let { preprocessors.preprocess(it) }
+
 		val theme = cardView.context.theme
 		val resources = cardView.resources
 

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
@@ -12,6 +12,7 @@ import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.android.core.utils.extensions.dpToPx
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Image
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Image] view
@@ -30,11 +31,14 @@ class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: Android
 	/**
 	 * Common functionality for both overridden [populateView] and [populateChildView]
 	 *
-	 * @param image the model to update UI state from, or null
-	 *  if null, should set UI to default state
-	 * @param defaultBgColour the default background colour to set if no other background colour is specified on the model
+	 * @param unprocessedImage The model to update UI state from, or null.
+	 *  If null, should set UI to default state
+	 * @param defaultBgColour The default background colour to set if no other background colour is specified on the model
 	 */
-	private fun populateView(image: Image?, @ColorRes defaultBgColour: Int) {
+	private fun populateView(unprocessedImage: Image?, @ColorRes defaultBgColour: Int) {
+		// Data preprocessing
+		val image = unprocessedImage?.let { viewConfig.preprocessors.filterIsInstance<Image.Preprocessor>().preprocess(it) }
+
 		binding.image.apply {
 			isVisible = image?.src?.url != null
 			viewConfig.imageLoader?.loadImage(image, this)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
@@ -59,6 +59,6 @@ class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: Android
 		)
 	}
 
-	override fun populateView(model: Image) = populateView(model, R.color.fusion_default_image_view_background_colour)
-	override fun populateChildView(model: Image?) = populateView(model, android.R.color.transparent)
+	override fun populateView(unprocessedModel: Image) = populateView(unprocessedModel, R.color.fusion_default_image_view_background_colour)
+	override fun populateChildView(unprocessedModel: Image?) = populateView(unprocessedModel, android.R.color.transparent)
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
@@ -10,6 +10,7 @@ import com.cube.fusion.android.core.databinding.ImageViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.android.core.utils.extensions.dpToPx
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Image
 
 /**
@@ -50,10 +51,11 @@ class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: Android
 		}
 
 		populateBaseView(
-			binding.imageContainer,
-			image?.baseProperties,
-			defaultBgColour,
-			R.dimen.fusion_default_image_view_corner_radius
+			cardView = binding.imageContainer,
+			unprocessedProperties = image?.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = defaultBgColour,
+			defaultCornerRadiusResId = R.dimen.fusion_default_image_view_corner_radius
 		)
 	}
 

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
@@ -10,9 +10,7 @@ import com.cube.fusion.android.core.databinding.ImageViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.android.core.utils.extensions.dpToPx
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Image
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Image] view
@@ -37,7 +35,7 @@ class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: Android
 	 */
 	private fun populateView(unprocessedImage: Image?, @ColorRes defaultBgColour: Int) {
 		// Data preprocessing
-		val image = unprocessedImage?.let { viewConfig.preprocessors.filterIsInstance<Image.Preprocessor>().preprocess(it) }
+		val image = unprocessedImage?.let { viewConfig.preprocessors.preprocess(Image::class, it) }
 
 		binding.image.apply {
 			isVisible = image?.src?.url != null
@@ -57,7 +55,7 @@ class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: Android
 		populateBaseView(
 			cardView = binding.imageContainer,
 			unprocessedProperties = image?.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = defaultBgColour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_image_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
@@ -10,6 +10,7 @@ import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.ListItem
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [ListItem] view
@@ -40,26 +41,29 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 	}
 
 	override fun populateView(unprocessedModel: ListItem) {
-		imageViewHolder.populateChildView(unprocessedModel.image)
-		titleViewHolder.populateChildView( unprocessedModel.title)
-		subtitleViewHolder.populateChildView(unprocessedModel.subtitle)
+		// Data preprocessing
+		val model = viewConfig.preprocessors.filterIsInstance<ListItem.Preprocessor>().preprocess(unprocessedModel)
+		
+		imageViewHolder.populateChildView(model.image)
+		titleViewHolder.populateChildView( model.title)
+		subtitleViewHolder.populateChildView(model.subtitle)
 
 		populateBaseView(
 			cardView = binding.cardContainer,
-			unprocessedProperties = unprocessedModel.baseProperties,
+			unprocessedProperties = model.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_list_item_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_list_item_view_corner_radius
 		)
 
 		//Apply padding
-		binding.listItemContainer.setPadding(unprocessedModel.baseProperties.padding)
+		binding.listItemContainer.setPadding(model.baseProperties.padding)
 
 		binding.cardContainer.setOnClickListener {
-			viewConfig.actionHandler.handleAction(it, unprocessedModel.action)
+			viewConfig.actionHandler.handleAction(it, model.action)
 		}
-		binding.cardContainer.isClickable = unprocessedModel.action != null
-		binding.cardContainer.isEnabled = unprocessedModel.action != null
-		binding.chevron.isVisible = unprocessedModel.action != null
+		binding.cardContainer.isClickable = model.action != null
+		binding.cardContainer.isEnabled = model.action != null
+		binding.chevron.isVisible = model.action != null
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
@@ -39,27 +39,27 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 		}
 	}
 
-	override fun populateView(model: ListItem) {
-		imageViewHolder.populateChildView(model.image)
-		titleViewHolder.populateChildView( model.title)
-		subtitleViewHolder.populateChildView(model.subtitle)
+	override fun populateView(unprocessedModel: ListItem) {
+		imageViewHolder.populateChildView(unprocessedModel.image)
+		titleViewHolder.populateChildView( unprocessedModel.title)
+		subtitleViewHolder.populateChildView(unprocessedModel.subtitle)
 
 		populateBaseView(
 			cardView = binding.cardContainer,
-			unprocessedProperties = model.baseProperties,
+			unprocessedProperties = unprocessedModel.baseProperties,
 			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = R.color.fusion_default_list_item_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_list_item_view_corner_radius
 		)
 
 		//Apply padding
-		binding.listItemContainer.setPadding(model.baseProperties.padding)
+		binding.listItemContainer.setPadding(unprocessedModel.baseProperties.padding)
 
 		binding.cardContainer.setOnClickListener {
-			viewConfig.actionHandler.handleAction(it, model.action)
+			viewConfig.actionHandler.handleAction(it, unprocessedModel.action)
 		}
-		binding.cardContainer.isClickable = model.action != null
-		binding.cardContainer.isEnabled = model.action != null
-		binding.chevron.isVisible = model.action != null
+		binding.cardContainer.isClickable = unprocessedModel.action != null
+		binding.cardContainer.isEnabled = unprocessedModel.action != null
+		binding.chevron.isVisible = unprocessedModel.action != null
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
@@ -8,6 +8,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.ListItemViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.ListItem
 
 /**
@@ -44,10 +45,11 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 		subtitleViewHolder.populateChildView(model.subtitle)
 
 		populateBaseView(
-			binding.cardContainer,
-			model.baseProperties,
-			R.color.fusion_default_list_item_view_background_colour,
-			R.dimen.fusion_default_list_item_view_corner_radius
+			cardView = binding.cardContainer,
+			unprocessedProperties = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = R.color.fusion_default_list_item_view_background_colour,
+			defaultCornerRadiusResId = R.dimen.fusion_default_list_item_view_corner_radius
 		)
 
 		//Apply padding

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
@@ -8,9 +8,7 @@ import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.databinding.ListItemViewBinding
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.ListItem
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [ListItem] view
@@ -42,7 +40,7 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 
 	override fun populateView(unprocessedModel: ListItem) {
 		// Data preprocessing
-		val model = viewConfig.preprocessors.filterIsInstance<ListItem.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(ListItem::class, unprocessedModel)
 		
 		imageViewHolder.populateChildView(model.image)
 		titleViewHolder.populateChildView( model.title)
@@ -51,7 +49,7 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 		populateBaseView(
 			cardView = binding.cardContainer,
 			unprocessedProperties = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = R.color.fusion_default_list_item_view_background_colour,
 			defaultCornerRadiusResId = R.dimen.fusion_default_list_item_view_corner_radius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
@@ -21,6 +21,7 @@ import com.cube.fusion.android.core.utils.extensions.asGravity
 import com.cube.fusion.android.core.utils.extensions.getDimenOrEms
 import com.cube.fusion.android.core.utils.extensions.resolveAsTypeface
 import com.cube.fusion.android.core.utils.extensions.toTypeface
+import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Text
 
 /**
@@ -121,7 +122,8 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 
 		populateBaseView(
 			cardView = binding.textContainer,
-			baseProperties = textModel?.baseProperties,
+			unprocessedProperties = textModel?.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
 			defaultBackgroundColourResId = defaultBgColour,
 			defaultCornerRadiusResId = defaultCornerRadius
 		)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
@@ -23,6 +23,7 @@ import com.cube.fusion.android.core.utils.extensions.resolveAsTypeface
 import com.cube.fusion.android.core.utils.extensions.toTypeface
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Text
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 
 /**
  * [FusionViewHolder] implementation to represent the [Text] view
@@ -42,14 +43,41 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 		/**
 		 * Common functionality for updating a [TextView] with properties from the [Text] model
 		 *
-		 * @param textModel the model to update UI state from, or null
-		 *  if null, should set UI to default state
-		 * @param defaultTextSize the resource ID for the default text size to set if no other text size is specified on the model
-		 * @param defaultTextColour the resource ID for the default text colour to set if no other text colour is specified on the model
-		 * @param defaultLetterSpacing the resource ID for the default letter spacing to set if no other letter spacing is specified on the model
-		 * @param defaultGravity the default gravity to set if no other gravity is specified on the model
+		 * @param textView The view to update the UI of
+		 * @param unprocessedModel The unprocessed model to update UI state from, or null.
+		 *  If null, should set UI to default state.
+		 * @param preprocessors A list of pre-processing steps to apply to the unprocessed text model before updating the UI
+		 * @param defaultTextSize The resource ID for the default text size to set if no other text size is specified on the model
+		 * @param defaultTextColour The resource ID for the default text colour to set if no other text colour is specified on the model
+		 * @param defaultLetterSpacing The resource ID for the default letter spacing to set if no other letter spacing is specified on the model
+		 * @param defaultGravity The default gravity to set if no other gravity is specified on the model
 		 */
-		fun populateView(textView: TextView, textModel: Text?, @DimenRes defaultTextSize: Int, @ColorRes defaultTextColour: Int, @DimenRes defaultLetterSpacing: Int, defaultGravity: Int) {
+		fun populateView(textView: TextView, unprocessedModel: Text?, preprocessors: List<Text.Preprocessor>, @DimenRes defaultTextSize: Int, @ColorRes defaultTextColour: Int, @DimenRes defaultLetterSpacing: Int, defaultGravity: Int) {
+			// Data pre-processing
+			val textModel = unprocessedModel?.let { preprocessors.preprocess(it) }
+
+			populateView(
+				textView = textView,
+				textModel = textModel,
+				defaultTextSize = defaultTextSize,
+				defaultTextColour = defaultTextColour,
+				defaultLetterSpacing = defaultLetterSpacing,
+				defaultGravity = defaultGravity
+			)
+		}
+
+		/**
+		 * Common functionality for updating a [TextView] with properties from the [Text] model
+		 *
+		 * @param textView The view to update the UI of
+		 * @param textModel The pre-processed [Text] model to update UI state from, or null.
+		 *  If null, should set UI to default state.
+		 * @param defaultTextSize The resource ID for the default text size to set if no other text size is specified on the model
+		 * @param defaultTextColour The resource ID for the default text colour to set if no other text colour is specified on the model
+		 * @param defaultLetterSpacing The resource ID for the default letter spacing to set if no other letter spacing is specified on the model
+		 * @param defaultGravity The default gravity to set if no other gravity is specified on the model
+		 */
+		private fun populateView(textView: TextView, textModel: Text?, @DimenRes defaultTextSize: Int, @ColorRes defaultTextColour: Int, @DimenRes defaultLetterSpacing: Int, defaultGravity: Int) {
 			textView.apply {
 				textModel?.font?.size?.let {
 					setTextSize(TypedValue.COMPLEX_UNIT_SP, it)
@@ -101,16 +129,20 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 	/**
 	 * Common functionality for updating the [TextViewBinding] with properties of the [Text] model
 	 *
-	 * @param textModel the model to update UI state from, or null
-	 *  if null, should set UI to default state
-	 * @param defaultBgColour the default background colour to set if no other background colour is specified on the model
-	 * @param defaultCornerRadius the resource ID for the default corner radius to set if no other corner radius is specified on the model
-	 * @param defaultTextSize the resource ID for the default text size to set if no other text size is specified on the model
-	 * @param defaultTextColour the resource ID for the default text colour to set if no other text colour is specified on the model
-	 * @param defaultLetterSpacing the resource ID for the default letter spacing to set if no other letter spacing is specified on the model
-	 * @param defaultGravity the default gravity to set if no other gravity is specified on the model
+	 * @param unprocessedModel The unprocessed model to update UI state from, or null.
+	 *  If null, should set UI to default state.
+	 * @param defaultBgColour The default background colour to set if no other background colour is specified on the model
+	 * @param defaultCornerRadius The resource ID for the default corner radius to set if no other corner radius is specified on the model
+	 * @param defaultTextSize The resource ID for the default text size to set if no other text size is specified on the model
+	 * @param defaultTextColour The resource ID for the default text colour to set if no other text colour is specified on the model
+	 * @param defaultLetterSpacing The resource ID for the default letter spacing to set if no other letter spacing is specified on the model
+	 * @param defaultGravity The default gravity to set if no other gravity is specified on the model
 	 */
-	fun populateView(textModel: Text?, @ColorRes defaultBgColour: Int, @DimenRes defaultCornerRadius: Int, @DimenRes defaultTextSize : Int, @ColorRes defaultTextColour : Int, @DimenRes defaultLetterSpacing : Int, defaultGravity: Int) {
+	fun populateView(unprocessedModel: Text?, @ColorRes defaultBgColour: Int, @DimenRes defaultCornerRadius: Int, @DimenRes defaultTextSize : Int, @ColorRes defaultTextColour : Int, @DimenRes defaultLetterSpacing : Int, defaultGravity: Int) {
+		// Data pre-processing
+		val preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>()
+		val textModel = unprocessedModel?.let { preprocessors.preprocess(it) }
+
 		populateView(
 			textView = binding.text,
 			textModel = textModel,
@@ -130,7 +162,7 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 	}
 
 	override fun populateView(unprocessedModel: Text) = populateView(
-		textModel = unprocessedModel,
+		unprocessedModel = unprocessedModel,
 		defaultBgColour = R.color.fusion_default_text_view_background_colour,
 		defaultCornerRadius = R.dimen.fusion_default_text_view_corner_radius,
 		defaultTextSize = R.dimen.fusion_default_text_view_text_size,
@@ -140,7 +172,7 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 	)
 
 	override fun populateChildView(unprocessedModel: Text?) = populateView(
-		textModel = unprocessedModel,
+		unprocessedModel = unprocessedModel,
 		defaultBgColour = android.R.color.transparent,
 		defaultCornerRadius = R.dimen.fusion_default_text_view_corner_radius,
 		defaultTextSize = R.dimen.fusion_default_text_view_text_size,

--- a/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
@@ -129,8 +129,8 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 		)
 	}
 
-	override fun populateView(model: Text) = populateView(
-		textModel = model,
+	override fun populateView(unprocessedModel: Text) = populateView(
+		textModel = unprocessedModel,
 		defaultBgColour = R.color.fusion_default_text_view_background_colour,
 		defaultCornerRadius = R.dimen.fusion_default_text_view_corner_radius,
 		defaultTextSize = R.dimen.fusion_default_text_view_text_size,
@@ -139,8 +139,8 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 		defaultGravity = Gravity.START
 	)
 
-	override fun populateChildView(model: Text?) = populateView(
-		textModel = model,
+	override fun populateChildView(unprocessedModel: Text?) = populateView(
+		textModel = unprocessedModel,
 		defaultBgColour = android.R.color.transparent,
 		defaultCornerRadius = R.dimen.fusion_default_text_view_corner_radius,
 		defaultTextSize = R.dimen.fusion_default_text_view_text_size,

--- a/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
@@ -21,9 +21,8 @@ import com.cube.fusion.android.core.utils.extensions.asGravity
 import com.cube.fusion.android.core.utils.extensions.getDimenOrEms
 import com.cube.fusion.android.core.utils.extensions.resolveAsTypeface
 import com.cube.fusion.android.core.utils.extensions.toTypeface
-import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.Text
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
+import com.cube.fusion.core.processor.FusionDataPreprocessorCollection
 
 /**
  * [FusionViewHolder] implementation to represent the [Text] view
@@ -52,9 +51,9 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 		 * @param defaultLetterSpacing The resource ID for the default letter spacing to set if no other letter spacing is specified on the model
 		 * @param defaultGravity The default gravity to set if no other gravity is specified on the model
 		 */
-		fun populateView(textView: TextView, unprocessedModel: Text?, preprocessors: List<Text.Preprocessor>, @DimenRes defaultTextSize: Int, @ColorRes defaultTextColour: Int, @DimenRes defaultLetterSpacing: Int, defaultGravity: Int) {
+		fun populateView(textView: TextView, unprocessedModel: Text?, preprocessors: FusionDataPreprocessorCollection, @DimenRes defaultTextSize: Int, @ColorRes defaultTextColour: Int, @DimenRes defaultLetterSpacing: Int, defaultGravity: Int) {
 			// Data pre-processing
-			val textModel = unprocessedModel?.let { preprocessors.preprocess(it) }
+			val textModel = unprocessedModel?.let { preprocessors.preprocess(Text::class, it) }
 
 			populateView(
 				textView = textView,
@@ -140,8 +139,8 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 	 */
 	fun populateView(unprocessedModel: Text?, @ColorRes defaultBgColour: Int, @DimenRes defaultCornerRadius: Int, @DimenRes defaultTextSize : Int, @ColorRes defaultTextColour : Int, @DimenRes defaultLetterSpacing : Int, defaultGravity: Int) {
 		// Data pre-processing
-		val preprocessors = viewConfig.preprocessors.filterIsInstance<Text.Preprocessor>()
-		val textModel = unprocessedModel?.let { preprocessors.preprocess(it) }
+		val preprocessors = viewConfig.preprocessors
+		val textModel = unprocessedModel?.let { preprocessors.preprocess(Text::class, it) }
 
 		populateView(
 			textView = binding.text,
@@ -155,7 +154,7 @@ class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFu
 		populateBaseView(
 			cardView = binding.textContainer,
 			unprocessedProperties = textModel?.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = defaultBgColour,
 			defaultCornerRadiusResId = defaultCornerRadius
 		)

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-retrofit:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "18be4df3c8"
+	def currentLibVersion = "e3c7849631"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-retrofit:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "v0.0.4-rc1"
+	def currentLibVersion = "v0.0.4-rc4"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-retrofit:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "e3c7849631"
+	def currentLibVersion = "v0.0.4-rc1"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"
 	implementation "com.github.3sidedcube.Android-Fusion-AndroidUi:activity:$currentLibVersion"
 

--- a/demoapp/src/main/assets/second.json
+++ b/demoapp/src/main/assets/second.json
@@ -35,6 +35,19 @@
 					"bottom": 5
 				},
 				"background_color": "#DDEEFF"
+			},
+			{
+				"class": "Button",
+				"content": "This is a button that does nothing!",
+				"margin": {
+					"left": 5,
+					"right": 5,
+					"top": 5,
+					"bottom": 5
+				},
+				"font": {
+					"size": 14
+				}
 			}
 		]
 	}

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -63,12 +63,10 @@ class ContentActivityImpl : FusionContentActivity() {
 		}
 		val localSource = AssetsPageSource(this, { it }, resolvers.values)
 		val preprocessors = FusionDataPreprocessorCollection()
-		preprocessors[Text::class] = object : FusionDataPreprocessor<Text> {
-			override fun preprocess(data: Text): Text {
-				return data.copy(
-					textColor = "#A2A2FF"
-				)
-			}
+		preprocessors[Text::class] = FusionDataPreprocessor { data ->
+			data.copy(
+				textColor = "#A2A2FF"
+			)
 		}
 		preprocessors[ListItem::class] = object : FusionDataPreprocessor<ListItem> {
 			private fun withoutBorder(text: Text?) = text?.let {
@@ -80,8 +78,8 @@ class ContentActivityImpl : FusionContentActivity() {
 				subtitle = withoutBorder(data.subtitle)
 			)
 		}
-		preprocessors[BaseViewProperties::class] = object : FusionDataPreprocessor<BaseViewProperties> {
-			override fun preprocess(data: BaseViewProperties) = data.copy(
+		preprocessors[BaseViewProperties::class] = FusionDataPreprocessor { data ->
+			data.copy(
 				backgroundColor = data.backgroundColor ?: "#EDEDED",
 				cornerRadius = data.cornerRadius ?: 5f,
 				border = data.border ?: Border(strokeWidth = 1f, color = "#BDBDBD")

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -17,9 +17,12 @@ import com.cube.fusion.android.demoapp.databinding.ActivityFusionImplBinding
 import com.cube.fusion.android.demoapp.holder.CardViewHolder
 import com.cube.fusion.android.demoapp.images.PicassoImageLoader
 import com.cube.fusion.android.demoapp.model.Card
+import com.cube.fusion.core.model.Border
+import com.cube.fusion.core.model.views.BaseViewProperties
+import com.cube.fusion.core.model.views.ListItem
 import com.cube.fusion.core.model.views.Text
+import com.cube.fusion.populator.coroutinesourcecache.CoroutineSourceCachePopulator
 import com.cube.fusion.populator.coroutinesourcecache.source.AssetsPageSource
-import com.cube.fusion.populator.retrofit.RetrofitDisplayPopulator
 
 /**
  * Content Activity implementation for the demo of Fusion AndroidUi
@@ -58,7 +61,7 @@ class ContentActivityImpl : FusionContentActivity() {
 		}
 		val localSource = AssetsPageSource(this, { it }, resolvers.values)
 		return AndroidFusionConfig(
-			populator = RetrofitDisplayPopulator(this::lifecycleScope, baseUrl, resolvers.values, localSource),
+			populator = CoroutineSourceCachePopulator(this::lifecycleScope, localSource),
 			resolvers = resolvers,
 			viewConfig = AndroidFusionViewConfig(
 				actionHandler = DefaultActivityActionHandlers { view, action ->
@@ -73,6 +76,23 @@ class ContentActivityImpl : FusionContentActivity() {
 					object : Text.Preprocessor {
 						override fun preprocess(data: Text) = data.copy(
 							textColor = "#A2A2FF"
+						)
+					},
+					object : ListItem.Preprocessor {
+						private fun withoutBorder(text: Text?) = text?.let {
+							it.copy(baseProperties = it.baseProperties.copy(border = Border(strokeWidth = 0f, color = "#00000000")))
+						}
+
+						override fun preprocess(data: ListItem): ListItem = data.copy(
+							title = withoutBorder(data.title),
+							subtitle = withoutBorder(data.subtitle)
+						)
+					},
+					object: BaseViewProperties.Preprocessor {
+						override fun preprocess(data: BaseViewProperties) = data.copy(
+							backgroundColor = data.backgroundColor ?: "#EDEDED",
+							cornerRadius = data.cornerRadius ?: 5f,
+							border = data.border ?: Border(strokeWidth = 1f, color = "#BDBDBD")
 						)
 					}
 				)

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -17,6 +17,7 @@ import com.cube.fusion.android.demoapp.databinding.ActivityFusionImplBinding
 import com.cube.fusion.android.demoapp.holder.CardViewHolder
 import com.cube.fusion.android.demoapp.images.PicassoImageLoader
 import com.cube.fusion.android.demoapp.model.Card
+import com.cube.fusion.core.model.views.Text
 import com.cube.fusion.populator.coroutinesourcecache.source.AssetsPageSource
 import com.cube.fusion.populator.retrofit.RetrofitDisplayPopulator
 
@@ -68,7 +69,14 @@ class ContentActivityImpl : FusionContentActivity() {
 					}
 				},
 				imageLoader = PicassoImageLoader,
-			)
+				preprocessors = listOf(
+					object : Text.Preprocessor {
+						override fun preprocess(data: Text) = data.copy(
+							textColor = "#A2A2FF"
+						)
+					}
+				)
+			),
 		)
 	}
 

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -21,8 +21,8 @@ import com.cube.fusion.core.model.Border
 import com.cube.fusion.core.model.views.BaseViewProperties
 import com.cube.fusion.core.model.views.ListItem
 import com.cube.fusion.core.model.views.Text
-import com.cube.fusion.populator.coroutinesourcecache.CoroutineSourceCachePopulator
 import com.cube.fusion.populator.coroutinesourcecache.source.AssetsPageSource
+import com.cube.fusion.populator.retrofit.RetrofitDisplayPopulator
 
 /**
  * Content Activity implementation for the demo of Fusion AndroidUi
@@ -61,7 +61,7 @@ class ContentActivityImpl : FusionContentActivity() {
 		}
 		val localSource = AssetsPageSource(this, { it }, resolvers.values)
 		return AndroidFusionConfig(
-			populator = CoroutineSourceCachePopulator(this::lifecycleScope, localSource),
+			populator = RetrofitDisplayPopulator(this::lifecycleScope, baseUrl, resolvers.values, localSource),
 			resolvers = resolvers,
 			viewConfig = AndroidFusionViewConfig(
 				actionHandler = DefaultActivityActionHandlers { view, action ->

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
@@ -10,8 +10,6 @@ import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.android.demoapp.R
 import com.cube.fusion.android.demoapp.databinding.CardViewBinding
 import com.cube.fusion.android.demoapp.model.Card
-import com.cube.fusion.core.model.views.BaseViewProperties
-import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 import com.squareup.picasso.Picasso
 
 /**
@@ -31,7 +29,7 @@ class CardViewHolder(private val binding: CardViewBinding, viewConfig: AndroidFu
 
 	override fun populateView(unprocessedModel: Card) {
 		// Pre-process data
-		val model = viewConfig.preprocessors.filterIsInstance<Card.Preprocessor>().preprocess(unprocessedModel)
+		val model = viewConfig.preprocessors.preprocess(Card::class, unprocessedModel)
 
 		//Custom properties
 		binding.title.isVisible = model.title != null
@@ -52,7 +50,7 @@ class CardViewHolder(private val binding: CardViewBinding, viewConfig: AndroidFu
 		populateBaseView(
 			cardView = binding.root,
 			unprocessedProperties = model.baseProperties,
-			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			preprocessors = viewConfig.preprocessors,
 			defaultBackgroundColourResId = android.R.color.transparent,
 			defaultCornerRadiusResId = R.dimen.card_view_default_corner_radius
 		)

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
@@ -10,6 +10,8 @@ import com.cube.fusion.android.core.utils.PaddingUtils.setPadding
 import com.cube.fusion.android.demoapp.R
 import com.cube.fusion.android.demoapp.databinding.CardViewBinding
 import com.cube.fusion.android.demoapp.model.Card
+import com.cube.fusion.core.model.views.BaseViewProperties
+import com.cube.fusion.core.utils.CollectionExtensions.preprocess
 import com.squareup.picasso.Picasso
 
 /**
@@ -27,7 +29,10 @@ class CardViewHolder(private val binding: CardViewBinding, viewConfig: AndroidFu
 		}
 	}
 
-	override fun populateView(model: Card) {
+	override fun populateView(unprocessedModel: Card) {
+		// Pre-process data
+		val model = viewConfig.preprocessors.filterIsInstance<Card.Preprocessor>().preprocess(unprocessedModel)
+
 		//Custom properties
 		binding.title.isVisible = model.title != null
 		binding.title.text = model.title ?: ""
@@ -45,10 +50,11 @@ class CardViewHolder(private val binding: CardViewBinding, viewConfig: AndroidFu
 
 		//Base properties
 		populateBaseView(
-			binding.root,
-			model.baseProperties,
-			android.R.color.transparent,
-			R.dimen.card_view_default_corner_radius
+			cardView = binding.root,
+			unprocessedProperties = model.baseProperties,
+			preprocessors = viewConfig.preprocessors.filterIsInstance<BaseViewProperties.Preprocessor>(),
+			defaultBackgroundColourResId = android.R.color.transparent,
+			defaultCornerRadiusResId = R.dimen.card_view_default_corner_radius
 		)
 	}
 }

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/model/Card.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/model/Card.kt
@@ -3,7 +3,6 @@ package com.cube.fusion.android.demoapp.model
 import com.cube.fusion.core.model.ImageSource
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.views.BaseViewProperties
-import com.cube.fusion.core.processor.FusionDataPreprocessor
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import kotlinx.parcelize.Parcelize
 
@@ -25,6 +24,4 @@ data class Card(
 	val type: String? = null,
 	val image: ImageSource? = null,
 	@field:JsonUnwrapped val baseProperties: BaseViewProperties = BaseViewProperties()
-): Model() {
-	interface Preprocessor: FusionDataPreprocessor<Card>
-}
+): Model()

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/model/Card.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/model/Card.kt
@@ -3,6 +3,7 @@ package com.cube.fusion.android.demoapp.model
 import com.cube.fusion.core.model.ImageSource
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.views.BaseViewProperties
+import com.cube.fusion.core.processor.FusionDataPreprocessor
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import kotlinx.parcelize.Parcelize
 
@@ -24,4 +25,6 @@ data class Card(
 	val type: String? = null,
 	val image: ImageSource? = null,
 	@field:JsonUnwrapped val baseProperties: BaseViewProperties = BaseViewProperties()
-): Model()
+): Model() {
+	interface Preprocessor: FusionDataPreprocessor<Card>
+}

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
@@ -12,6 +12,7 @@ import com.cube.fusion.android.core.images.ImageLoadingManager
 import com.cube.fusion.android.fragment.FusionContentFragment
 import com.cube.fusion.android.fragment.R
 import com.cube.fusion.android.fragment.factory.FusionContentFragmentFactory
+import com.cube.fusion.core.processor.FusionDataPreprocessorCollection
 import com.cube.fusion.populator.legacy.LegacyDisplayPopulator
 
 /**
@@ -36,7 +37,7 @@ class LegacyContentActivity : AppCompatActivity() {
 		viewConfig = AndroidFusionViewConfig(
 			actionHandler = DefaultActivityActionHandlers(LegacyContentActivity::class.java),
 			imageLoader = ImageLoadingManager.imageLoader,
-			preprocessors = emptyList()
+			preprocessors = FusionDataPreprocessorCollection()
 		)
 	)
 	private val fragmentFactory = FusionContentFragmentFactory(fusionConfig)

--- a/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
+++ b/fragment/src/main/java/com/cube/fusion/android/fragment/activity/LegacyContentActivity.kt
@@ -36,6 +36,7 @@ class LegacyContentActivity : AppCompatActivity() {
 		viewConfig = AndroidFusionViewConfig(
 			actionHandler = DefaultActivityActionHandlers(LegacyContentActivity::class.java),
 			imageLoader = ImageLoadingManager.imageLoader,
+			preprocessors = emptyList()
 		)
 	)
 	private val fragmentFactory = FusionContentFragmentFactory(fusionConfig)


### PR DESCRIPTION
### What?
- Adds a list of preprocessor steps as a property of the `AndroidViewConfig` data class
- Updates all `FusionViewHolder`s so that the default argument is an _unprocessed_ model, and so that they use this list of preprocessor steps to pre-process the model data before updating UI with it
- Updates the demo app to fit this pattern and to use data pre-processing steps

### Why?
This will allow for Fusion data to have preprocessing steps applied to it directly before populating the UI, allowing for features like:

- Dynamic localisation of text
- Styles which are automatically applied to views missing any declared style information

Additionally, with a proposed future feature (extensions on views), this will allow for far greater customisation of Fusion UI

### Anything else?
Please review [this PR in the Core library](https://github.com/3sidedcube/Android-Fusion-Core/pull/14) at the same time as this.

This implementation does introduce a tiny amount of boilerplate (having to register a new preprocessor interface for each model class, having to pre-process the data in the `ViewHolder`).
However, this will usually be 2 extra lines of code per new model type, which is relatively minimal - and, custom views in final projects (i.e release apps rather than libraries) may not even need to add pre-processing steps, if the `ViewHolder`s can be directly manipulated.
The rationale for using this pattern is that it bypasses generic type erasure to ensure that only the pre-processor steps for that specific type of model are applied.
All other approaches I could think of for implementing this pre-processing would have led to some sort of unsafe cast, putting the responsibility on the developer to make sure their preprocessor implementations were safe.
If you can think of a cleaner approach that is as safe as this approach, please let me know.