### PR TITLE
Feature/update adapter resolver logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def withConsistentVersioning(requiredVersion) {
 ext {
 	// Do not remove the call to withConsistentVersioning - this ensures that versions for all Fusion libs are aligned.
 	// Instead, update the argument passed to withConsistentVersioning to the target lib version
-	fusionLibVersion = withConsistentVersioning('v0.0.4-alpha1')
+	fusionLibVersion = withConsistentVersioning('v0.0.4-alpha2')
 }
 
 task clean(type: Delete) {

--- a/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
@@ -119,7 +119,7 @@ class FusionViewAdapter(
 			}
 		}
 		else {
-			val holderClass = resolvers[item.`class`]?.resolveViewHolder()
+			val holderClass = resolvers[item.`class`]?.viewHolderFactory
 			if (holderClass != null) {
 				items.add(index, item)
 			}
@@ -141,7 +141,7 @@ class FusionViewAdapter(
 	override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): FusionViewHolder<*> {
 		val holder: FusionViewHolder<*>
 		try {
-			val holderFactory = resolvers[resolverOrder[viewType]]!!.resolveViewHolder()
+			val holderFactory = resolvers[resolverOrder[viewType]]!!.viewHolderFactory
 			holder = holderFactory!!.createViewHolder(viewGroup, viewConfig)!!
 		}
 		catch (e: Exception) {

--- a/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
@@ -141,8 +141,8 @@ class FusionViewAdapter(
 	override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): FusionViewHolder<*> {
 		val holder: FusionViewHolder<*>
 		try {
-			val holderFactory = resolvers[resolverOrder[viewType]]!!.resolveViewHolder()!!.getConstructor().newInstance()!!
-			holder = holderFactory.createViewHolder(viewGroup, viewConfig)!!
+			val holderFactory = resolvers[resolverOrder[viewType]]!!.resolveViewHolder()
+			holder = holderFactory!!.createViewHolder(viewGroup, viewConfig)!!
 		}
 		catch (e: Exception) {
 			throw IllegalStateException("Could not instantiate a new holder" + e.message, e)

--- a/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/adapter/FusionViewAdapter.kt
@@ -6,12 +6,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.cube.fusion.android.core.config.AndroidFusionConfig
 import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.holder.FusionViewHolder
-import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
 import com.cube.fusion.android.core.resolver.AndroidViewResolver
 import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.model.views.Screen
 import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.RawValue
 
 /**
  * The base adapter used for displaying Fusion views in a list.
@@ -44,7 +42,7 @@ class FusionViewAdapter(
 	 * {@hide}
 	 */
 	@Parcelize
-	class AdapterState(val items: @RawValue ArrayList<Model>, val itemsTypes: ArrayList<Class<out FusionViewHolderFactory>?>) : Parcelable
+	class AdapterState(val items: ArrayList<Model>) : Parcelable
 
 	/**
 	 * The list of models of the views we are rendering in the list. This is a 1 dimensional representation
@@ -57,23 +55,22 @@ class FusionViewAdapter(
 	/**
 	 * The different unique item types. This is used to tell the adapter how many unique views we're
 	 * going to be rendering so it knows what and when to recycle. The list is just for index based
-	 * convenience, the object type in the list is a reference to the view holder class we will use
+	 * convenience, the object type in the list is a reference to the resolver we will use
 	 * to render said view.
 	 */
-	private var itemTypes = ArrayList<Class<out FusionViewHolderFactory>?>()
+	private var resolverOrder = resolvers.keys.sorted()
 
 	constructor(androidConfig: AndroidFusionConfig, items: Collection<Model>?) : this(androidConfig) {
 		setItems(items)
 	}
 
 	fun saveState(): AdapterState {
-		return AdapterState(items, itemTypes)
+		return AdapterState(items)
 	}
 
 	fun restoreState(state: AdapterState?) {
 		if (state != null) {
 			items = ArrayList(state.items)
-			itemTypes = ArrayList(state.itemsTypes)
 			notifyDataSetChanged()
 		}
 	}
@@ -86,14 +83,12 @@ class FusionViewAdapter(
 	fun setItems(items: Collection<Model>?) {
 		if (items != null) {
 			this.items = ArrayList(items.size)
-			itemTypes = ArrayList()
 			for (item in items) {
 				addItem(item)
 			}
 		}
 		else {
 			this.items = ArrayList()
-			itemTypes = ArrayList()
 		}
 		notifyDataSetChanged()
 	}
@@ -128,9 +123,6 @@ class FusionViewAdapter(
 			if (holderClass != null) {
 				items.add(index, item)
 			}
-			if (!itemTypes.contains(holderClass)) {
-				itemTypes.add(holderClass)
-			}
 		}
 	}
 
@@ -149,7 +141,7 @@ class FusionViewAdapter(
 	override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): FusionViewHolder<*> {
 		val holder: FusionViewHolder<*>
 		try {
-			val holderFactory = itemTypes[viewType]!!.getConstructor().newInstance()
+			val holderFactory = resolvers[resolverOrder[viewType]]!!.resolveViewHolder()!!.getConstructor().newInstance()!!
 			holder = holderFactory.createViewHolder(viewGroup, viewConfig)!!
 		}
 		catch (e: Exception) {
@@ -169,6 +161,6 @@ class FusionViewAdapter(
 
 	override fun getItemViewType(position: Int): Int {
 		val view = items[position]
-		return itemTypes.indexOf((resolvers[view.`class`] ?: error("")).resolveViewHolder())
+		return resolverOrder.indexOf(view.`class`)
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/helper/ViewHelper.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/helper/ViewHelper.kt
@@ -17,12 +17,12 @@ import com.cube.fusion.core.model.views.*
 object ViewHelper {
 	fun getDefaultViewResolvers(): MutableMap<String, AndroidViewResolver> = hashMapOf(
 		"Screen" to DefaultViewResolver(Screen::class.java, null),
-		"Text" to DefaultViewResolver(Text::class.java, TextViewHolder.Factory::class.java),
-		"Image" to DefaultViewResolver(Image::class.java, ImageViewHolder.Factory::class.java),
-		"Divider" to DefaultViewResolver(Divider::class.java, DividerViewHolder.Factory::class.java),
-		"ListItem" to DefaultViewResolver(ListItem::class.java, ListItemViewHolder.Factory::class.java),
-		"Button" to DefaultViewResolver(Button::class.java, ButtonViewHolder.Factory::class.java),
-		"BulletGroup" to DefaultViewResolver(BulletGroup::class.java, BulletGroupViewHolder.Factory::class.java),
-		"Bullet" to DefaultViewResolver(Bullet::class.java, BulletViewHolder.Factory::class.java)
+		"Text" to DefaultViewResolver(Text::class.java, TextViewHolder.Factory()),
+		"Image" to DefaultViewResolver(Image::class.java, ImageViewHolder.Factory()),
+		"Divider" to DefaultViewResolver(Divider::class.java, DividerViewHolder.Factory()),
+		"ListItem" to DefaultViewResolver(ListItem::class.java, ListItemViewHolder.Factory()),
+		"Button" to DefaultViewResolver(Button::class.java, ButtonViewHolder.Factory()),
+		"BulletGroup" to DefaultViewResolver(BulletGroup::class.java, BulletGroupViewHolder.Factory()),
+		"Bullet" to DefaultViewResolver(Bullet::class.java, BulletViewHolder.Factory())
 	)
 }

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletGroupViewHolder.kt
@@ -22,7 +22,7 @@ import com.cube.fusion.core.model.views.BulletGroup
  */
 class BulletGroupViewHolder(val binding: BulletGroupViewBinding, viewConfig: AndroidFusionViewConfig) :
 	FusionViewHolder<BulletGroup>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<BulletGroup> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): BulletGroupViewHolder {
 			val binding = BulletGroupViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return BulletGroupViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/BulletViewHolder.kt
@@ -30,7 +30,7 @@ class BulletViewHolder(val binding: BulletViewBinding, viewConfig: AndroidFusion
 		ViewCompat.setAccessibilityDelegate(binding.cardContainer, delegate)
 	}
 
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Bullet> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): BulletViewHolder {
 			val binding =
 				BulletViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ButtonViewHolder.kt
@@ -16,7 +16,7 @@ import com.cube.fusion.core.model.views.Button
  * Copyright ® 3SidedCube. All rights reserved.
  */
 class ButtonViewHolder(val binding: TextViewBinding, viewConfig: AndroidFusionViewConfig) : ChildViewHolder<Button>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Button> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): ButtonViewHolder {
 			val binding = TextViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return ButtonViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/DividerViewHolder.kt
@@ -19,7 +19,7 @@ import kotlin.math.roundToInt
  * Copyright ® 3SidedCube. All rights reserved.
  */
 class DividerViewHolder(private val binding: DividerViewBinding, viewConfig: AndroidFusionViewConfig) : FusionViewHolder<Divider>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Divider> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): DividerViewHolder {
 			val binding = DividerViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return DividerViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ImageViewHolder.kt
@@ -22,7 +22,7 @@ import com.cube.fusion.core.model.views.Image
  * Copyright ® 3SidedCube. All rights reserved.
  */
 class ImageViewHolder(private val binding: ImageViewBinding, viewConfig: AndroidFusionViewConfig) : ChildViewHolder<Image>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Image> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): ImageViewHolder {
 			val binding = ImageViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return ImageViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/ListItemViewHolder.kt
@@ -31,7 +31,7 @@ class ListItemViewHolder(private val binding: ListItemViewBinding, viewConfig: A
 		binding.cardContainer.registerChildViewHolder(imageViewHolder)
 	}
 
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<ListItem> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): ListItemViewHolder {
 			val binding = ListItemViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return ListItemViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/TextViewHolder.kt
@@ -30,7 +30,7 @@ import com.cube.fusion.core.model.views.Text
  * Copyright ® 3SidedCube. All rights reserved.
  */
 class TextViewHolder(private val binding: TextViewBinding, viewConfig: AndroidFusionViewConfig) : ChildViewHolder<Text>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Text> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): TextViewHolder {
 			val binding = TextViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return TextViewHolder(binding, viewConfig)

--- a/core/src/main/java/com/cube/fusion/android/core/holder/factory/FusionViewHolderFactory.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/holder/factory/FusionViewHolderFactory.kt
@@ -3,19 +3,22 @@ package com.cube.fusion.android.core.holder.factory
 import android.view.ViewGroup
 import com.cube.fusion.android.core.config.AndroidFusionViewConfig
 import com.cube.fusion.android.core.holder.FusionViewHolder
+import com.cube.fusion.core.model.Model
 
 /**
  * Interface for the creation of new [FusionViewHolder]s for Fusion views
  *
  * Created by Nikos Rapousis on 12/March/2021.
  * Copyright ® 3SidedCube. All rights reserved.
+ *
+ * @param T The type of model that the factory creates a [FusionViewHolder] for
  */
-interface FusionViewHolderFactory {
+interface FusionViewHolderFactory <T: Model> {
 	/**
 	 * Create a new [FusionViewHolder] within a given [ViewGroup]
 	 *
 	 * @param parent The [ViewGroup] to create the [FusionViewHolder] in
 	 * @param viewConfig A reference to the [AndroidFusionViewConfig] instance used for configuring views
 	 */
-	fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): FusionViewHolder<*>?
+	fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): FusionViewHolder<T>?
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
@@ -10,5 +10,5 @@ import com.cube.fusion.core.resolver.ViewResolver
  * Copyright ® 3SidedCube. All rights reserved.
  */
 interface AndroidViewResolver : ViewResolver {
-	fun resolveViewHolder(): Class<out FusionViewHolderFactory?>?
+	fun resolveViewHolder(): FusionViewHolderFactory?
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
@@ -1,6 +1,7 @@
 package com.cube.fusion.android.core.resolver
 
 import com.cube.fusion.android.core.holder.factory.FusionViewHolderFactory
+import com.cube.fusion.core.model.Model
 import com.cube.fusion.core.resolver.ViewResolver
 
 /**
@@ -10,5 +11,5 @@ import com.cube.fusion.core.resolver.ViewResolver
  * Copyright ® 3SidedCube. All rights reserved.
  */
 interface AndroidViewResolver : ViewResolver {
-	val viewHolderFactory: FusionViewHolderFactory?
+	val viewHolderFactory: FusionViewHolderFactory<out Model>?
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/AndroidViewResolver.kt
@@ -10,5 +10,5 @@ import com.cube.fusion.core.resolver.ViewResolver
  * Copyright ® 3SidedCube. All rights reserved.
  */
 interface AndroidViewResolver : ViewResolver {
-	fun resolveViewHolder(): FusionViewHolderFactory?
+	val viewHolderFactory: FusionViewHolderFactory?
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -10,12 +10,10 @@ import com.cube.fusion.core.model.Model
  * Created by Nikos Rapousis on 12/March/2021.
  * Copyright ® 3SidedCube. All rights reserved.
  *
- * @param view the view to resolve to
- * @param viewHolder the holder to resolve to
+ * @param view The class of the view to resolve to
+ * @param viewHolderFactory The factory to use in order to create views for the view
  */
-class DefaultViewResolver(val view: Class<out Model?>, viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
-	override val viewHolderFactory = viewHolder?.newInstance()
-
+class DefaultViewResolver(val view: Class<out Model?>, override val viewHolderFactory: FusionViewHolderFactory?) : AndroidViewResolver {
 	override fun resolveView(): Class<out Model?> {
 		return view
 	}

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -13,12 +13,14 @@ import com.cube.fusion.core.model.Model
  * @param view the view to resolve to
  * @param viewHolder the holder to resolve to
  */
-class DefaultViewResolver(var view: Class<out Model?>, var viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
+class DefaultViewResolver(var view: Class<out Model?>, viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
+	private val viewHolderFactory = viewHolder?.newInstance()
+
 	override fun resolveView(): Class<out Model?> {
 		return view
 	}
 
-	override fun resolveViewHolder(): Class<out FusionViewHolderFactory?>? {
-		return viewHolder
+	override fun resolveViewHolder(): FusionViewHolderFactory? {
+		return viewHolderFactory
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -14,13 +14,9 @@ import com.cube.fusion.core.model.Model
  * @param viewHolder the holder to resolve to
  */
 class DefaultViewResolver(var view: Class<out Model?>, viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
-	private val viewHolderFactory = viewHolder?.newInstance()
+	override val viewHolderFactory = viewHolder?.newInstance()
 
 	override fun resolveView(): Class<out Model?> {
 		return view
-	}
-
-	override fun resolveViewHolder(): FusionViewHolderFactory? {
-		return viewHolderFactory
 	}
 }

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -10,10 +10,11 @@ import com.cube.fusion.core.model.Model
  * Created by Nikos Rapousis on 12/March/2021.
  * Copyright ® 3SidedCube. All rights reserved.
  *
+ * @param T The type of the view to resolve to
  * @param view The class of the view to resolve to
- * @param viewHolderFactory The factory to use in order to create views for the view
+ * @param viewHolderFactory The factory to use in order to create views for views matching type [T] and class [view]
  */
-class DefaultViewResolver(val view: Class<out Model?>, override val viewHolderFactory: FusionViewHolderFactory<out Model>?) : AndroidViewResolver {
+class DefaultViewResolver<T: Model>(val view: Class<T>, override val viewHolderFactory: FusionViewHolderFactory<T>?) : AndroidViewResolver {
 	override fun resolveView(): Class<out Model?> {
 		return view
 	}

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -13,7 +13,7 @@ import com.cube.fusion.core.model.Model
  * @param view the view to resolve to
  * @param viewHolder the holder to resolve to
  */
-class DefaultViewResolver(var view: Class<out Model?>, viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
+class DefaultViewResolver(val view: Class<out Model?>, viewHolder: Class<out FusionViewHolderFactory?>?) : AndroidViewResolver {
 	override val viewHolderFactory = viewHolder?.newInstance()
 
 	override fun resolveView(): Class<out Model?> {

--- a/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
+++ b/core/src/main/java/com/cube/fusion/android/core/resolver/DefaultViewResolver.kt
@@ -13,7 +13,7 @@ import com.cube.fusion.core.model.Model
  * @param view The class of the view to resolve to
  * @param viewHolderFactory The factory to use in order to create views for the view
  */
-class DefaultViewResolver(val view: Class<out Model?>, override val viewHolderFactory: FusionViewHolderFactory?) : AndroidViewResolver {
+class DefaultViewResolver(val view: Class<out Model?>, override val viewHolderFactory: FusionViewHolderFactory<out Model>?) : AndroidViewResolver {
 	override fun resolveView(): Class<out Model?> {
 		return view
 	}

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 	implementation "com.github.3sidedcube.Android-Fusion-Core:populator-retrofit:${project.fusionLibVersion}"
 
 	// Same-repo Fusion dependencies
-	def currentLibVersion = "v0.0.4-alpha1"
+	def currentLibVersion = "v0.0.4-alpha2"
 	localImplementation project(":core")
 	localImplementation project(":activity")
 	jitpackImplementation "com.github.3sidedcube.Android-Fusion-AndroidUi:core:$currentLibVersion"

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/activity/ContentActivityImpl.kt
@@ -54,7 +54,7 @@ class ContentActivityImpl : FusionContentActivity() {
 	override val fusionConfig: AndroidFusionConfig get() {
 		val baseUrl = intent.getStringExtra(BASE_URL_EXTRA_KEY) ?: ""
 		val resolvers = ViewHelper.getDefaultViewResolvers().apply {
-			put("Card", DefaultViewResolver(Card::class.java, CardViewHolder.Factory::class.java))
+			put("Card", DefaultViewResolver(Card::class.java, CardViewHolder.Factory()))
 		}
 		val localSource = AssetsPageSource(this, { it }, resolvers.values)
 		return AndroidFusionConfig(

--- a/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
+++ b/demoapp/src/main/java/com/cube/fusion/android/demoapp/holder/CardViewHolder.kt
@@ -20,7 +20,7 @@ import com.cube.fusion.core.model.views.Image
  * Copyright ® 3SidedCube. All rights reserved.
  */
 class CardViewHolder(private val binding: CardViewBinding, viewConfig: AndroidFusionViewConfig) : FusionViewHolder<Card>(binding.root, viewConfig) {
-	class Factory : FusionViewHolderFactory {
+	class Factory : FusionViewHolderFactory<Card> {
 		override fun createViewHolder(parent: ViewGroup, viewConfig: AndroidFusionViewConfig): CardViewHolder {
 			val binding = CardViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 			return CardViewHolder(binding, viewConfig)


### PR DESCRIPTION
### What?
- Updates `FusionViewAdapter` so that it contains a list of resolver keys, rather than a list of `FusionViewHolderFactory` classes
- Generates this list at initialisation time via the `sorted()` method
- Adds a type parameter to `FusionViewHolderFactory` for the model type
- Replaces `AndroidViewResolver` `resolveViewHolder()` method with `viewHolderFactory` property, which holds an instance of `FusionViewHolderFactory` rather than its class
- Adds a type parameter to `DefaultViewResolver` so that the view and its viewholders match type

### Why?
This ensures that (when using `DefaultViewResolver`) the type of the view matches the type of the viewholder used for it, which was previously not guaranteed.
It also removes the unnecessary instantiation of `FusionViewHolderFactory` by constructor using reflection, which would fail if the factory implementation didn't have a no-arguments constructor.